### PR TITLE
Add recovery yield lego

### DIFF
--- a/contracts/legos/yield/RecoveryLego.vy
+++ b/contracts/legos/yield/RecoveryLego.vy
@@ -1,0 +1,461 @@
+#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md
+
+# @version 0.4.3
+
+implements: Lego
+implements: YieldLego
+
+exports: addys.__interface__
+exports: yld.__interface__
+
+initializes: addys
+initializes: yld[addys := addys]
+
+from interfaces import LegoPartner as Lego
+from interfaces import YieldLego as YieldLego
+from interfaces import WalletStructs as ws
+
+import contracts.modules.Addys as addys
+import contracts.modules.YieldLegoData as yld
+
+from ethereum.ercs import IERC20
+
+interface UndyHq:
+    def governance() -> address: view
+
+interface Ledger:
+    def isUserWallet(_user: address) -> bool: view
+
+struct Recovery:
+    user: address
+    asset: address
+    recipient: address
+
+event RecoveryDeposit:
+    user: indexed(address)
+    asset: indexed(address)
+    amount: uint256
+
+event FundsMigrated:
+    user: indexed(address)
+    asset: indexed(address)
+    recipient: indexed(address)
+    amount: uint256
+
+GOVERNANCE: public(immutable(address))
+
+MAX_TOKEN_PATH: constant(uint256) = 5
+MAX_PROOFS: constant(uint256) = 25
+MAX_RECOVERIES: constant(uint256) = 30
+
+# user -> asset -> amount
+userAssets: public(HashMap[address, HashMap[address, uint256]])
+
+
+@deploy
+def __init__(_undyHq: address, _governance: address):
+    assert empty(address) not in [_undyHq, _governance] # dev: invalid addrs
+    addys.__init__(_undyHq)
+    yld.__init__(False)
+    GOVERNANCE = _governance
+
+
+@view
+@internal
+def _canMigrate(_caller: address) -> bool:
+    if _caller == GOVERNANCE:
+        return True
+    return _caller == staticcall UndyHq(addys._getUndyHq()).governance()
+
+
+@view
+@internal
+def _isUserWallet(_wallet: address) -> bool:
+    ledger: address = addys._getLedgerAddr()
+    if ledger == empty(address):
+        return False
+    return staticcall Ledger(ledger).isUserWallet(_wallet)
+
+
+#########
+# Views #
+#########
+
+
+@view
+@external
+def hasCapability(_action: ws.ActionType) -> bool:
+    return _action == ws.ActionType.EARN_DEPOSIT
+
+
+@view
+@external
+def getRegistries() -> DynArray[address, 10]:
+    return []
+
+
+@view
+@external
+def isYieldLego() -> bool:
+    return True
+
+
+@view
+@external
+def isDexLego() -> bool:
+    return False
+
+
+###################
+# Underlying Data #
+###################
+
+
+@view
+@external
+def getUnderlyingAsset(_vaultToken: address) -> address:
+    return empty(address)
+
+
+@view
+@external
+def getUnderlyingBalances(_vaultToken: address, _vaultTokenBalance: uint256) -> (uint256, uint256):
+    return 0, 0
+
+
+@view
+@external
+def getUnderlyingAmount(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:
+    return 0
+
+
+@view
+@external
+def getUnderlyingAmountSafe(_vaultToken: address, _vaultTokenBalance: uint256) -> uint256:
+    return 0
+
+
+@view
+@external
+def getUnderlyingData(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> (address, uint256, uint256):
+    return empty(address), 0, 0
+
+
+@view
+@external
+def getUsdValueOfVaultToken(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> uint256:
+    return 0
+
+
+###############
+# Other Utils #
+###############
+
+
+@view
+@external
+def isRebasing() -> bool:
+    return False
+
+
+@view
+@external
+def getPricePerShare(_vaultToken: address, _decimals: uint256 = 0) -> uint256:
+    return 0
+
+
+@view
+@external
+def getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def canRegisterVaultToken(_asset: address, _vaultToken: address) -> bool:
+    return False
+
+
+@view
+@external
+def totalAssets(_vaultToken: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def totalBorrows(_vaultToken: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def getUtilizationRatio(_vaultToken: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def getAvailLiquidity(_vaultToken: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def isEligibleForYieldBonus(_asset: address) -> bool:
+    return False
+
+
+@view
+@external
+def getWithdrawalFees(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:
+    return 0
+
+
+#################
+# Yield Actions #
+#################
+
+
+@external
+def depositForYield(
+    _asset: address,
+    _amount: uint256,
+    _vaultAddr: address,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, address, uint256, uint256):
+    assert not yld.isPaused # dev: paused
+    assert self._isUserWallet(msg.sender) # dev: not a user wallet
+    assert _asset != empty(address) # dev: invalid asset
+
+    depositAmount: uint256 = min(_amount, staticcall IERC20(_asset).balanceOf(msg.sender))
+    assert depositAmount != 0 # dev: nothing to transfer
+    assert extcall IERC20(_asset).transferFrom(msg.sender, self, depositAmount, default_return_value=True) # dev: transfer failed
+
+    self.userAssets[msg.sender][_asset] += depositAmount
+
+    log RecoveryDeposit(user=msg.sender, asset=_asset, amount=depositAmount)
+    return depositAmount, empty(address), 0, 0
+
+
+@external
+def withdrawFromYield(
+    _vaultToken: address,
+    _amount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, address, uint256, uint256):
+    return 0, empty(address), 0, 0
+
+
+@external
+def migrateFunds(_recoveries: DynArray[Recovery, MAX_RECOVERIES]) -> bool:
+    assert self._canMigrate(msg.sender) # dev: no perms
+
+    for r: Recovery in _recoveries:
+        if empty(address) in [r.asset, r.recipient]:
+            continue
+
+        recordedAmount: uint256 = self.userAssets[r.user][r.asset]
+        if recordedAmount == 0:
+            continue
+
+        amount: uint256 = min(recordedAmount, staticcall IERC20(r.asset).balanceOf(self))
+        if amount == 0:
+            continue
+
+        self.userAssets[r.user][r.asset] = recordedAmount - amount
+        assert extcall IERC20(r.asset).transfer(r.recipient, amount, default_return_value=True) # dev: transfer failed
+        log FundsMigrated(user=r.user, asset=r.asset, recipient=r.recipient, amount=amount)
+
+    return True
+
+
+@external
+def addPriceSnapshot(_vaultToken: address) -> bool:
+    return False
+
+
+#########
+# Other #
+#########
+
+
+@view
+@external
+def getAccessForLego(_user: address, _action: ws.ActionType) -> (address, String[64], uint256):
+    return empty(address), empty(String[64]), 0
+
+
+@external
+def claimIncentives(
+    _user: address,
+    _rewardToken: address,
+    _rewardAmount: uint256,
+    _proofs: DynArray[bytes32, MAX_PROOFS],
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@pure
+@external
+def claimRewards(
+    _user: address,
+    _rewardToken: address,
+    _rewardAmount: uint256,
+    _extraData: bytes32,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def swapTokens(
+    _amountIn: uint256,
+    _minAmountOut: uint256,
+    _tokenPath: DynArray[address, MAX_TOKEN_PATH],
+    _poolPath: DynArray[address, MAX_TOKEN_PATH - 1],
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256, uint256):
+    return 0, 0, 0
+
+
+@external
+def mintOrRedeemAsset(
+    _tokenIn: address,
+    _tokenOut: address,
+    _tokenInAmount: uint256,
+    _minAmountOut: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256, bool, uint256):
+    return 0, 0, False, 0
+
+
+@external
+def confirmMintOrRedeemAsset(
+    _tokenIn: address,
+    _tokenOut: address,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def borrow(
+    _borrowAsset: address,
+    _amount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def repayDebt(
+    _paymentAsset: address,
+    _paymentAmount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def removeCollateral(
+    _asset: address,
+    _amount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def addCollateral(
+    _asset: address,
+    _amount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256):
+    return 0, 0
+
+
+@external
+def addLiquidity(
+    _pool: address,
+    _tokenA: address,
+    _tokenB: address,
+    _amountA: uint256,
+    _amountB: uint256,
+    _minAmountA: uint256,
+    _minAmountB: uint256,
+    _minLpAmount: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (address, uint256, uint256, uint256, uint256):
+    return empty(address), 0, 0, 0, 0
+
+
+@external
+def removeLiquidity(
+    _pool: address,
+    _tokenA: address,
+    _tokenB: address,
+    _lpToken: address,
+    _lpAmount: uint256,
+    _minAmountA: uint256,
+    _minAmountB: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256, uint256, uint256):
+    return 0, 0, 0, 0
+
+
+@external
+def addLiquidityConcentrated(
+    _nftTokenId: uint256,
+    _pool: address,
+    _tokenA: address,
+    _tokenB: address,
+    _tickLower: int24,
+    _tickUpper: int24,
+    _amountA: uint256,
+    _amountB: uint256,
+    _minAmountA: uint256,
+    _minAmountB: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256, uint256, uint256, uint256):
+    return 0, 0, 0, 0, 0
+
+
+@external
+def removeLiquidityConcentrated(
+    _nftTokenId: uint256,
+    _pool: address,
+    _tokenA: address,
+    _tokenB: address,
+    _liqToRemove: uint256,
+    _minAmountA: uint256,
+    _minAmountB: uint256,
+    _extraData: bytes32,
+    _recipient: address,
+    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),
+) -> (uint256, uint256, uint256, bool, uint256):
+    return 0, 0, 0, False, 0

--- a/contracts/legos/yield/RecoveryLego.vy
+++ b/contracts/legos/yield/RecoveryLego.vy
@@ -26,6 +26,12 @@ interface UndyHq:
 interface Ledger:
     def isUserWallet(_user: address) -> bool: view
 
+interface UserWallet:
+    def walletConfig() -> address: view
+
+interface UserWalletConfig:
+    def indexOfManager() -> uint256: view
+
 struct Recovery:
     user: address
     asset: address
@@ -42,29 +48,26 @@ event FundsMigrated:
     recipient: indexed(address)
     amount: uint256
 
-GOVERNANCE: public(immutable(address))
-
 MAX_TOKEN_PATH: constant(uint256) = 5
 MAX_PROOFS: constant(uint256) = 25
 MAX_RECOVERIES: constant(uint256) = 30
+
+AGENT_WRAPPER: constant(address) = 0x8ee401f1E0F4CC0Ed57318AB6dAab1F1Fb59f65f
 
 # user -> asset -> amount
 userAssets: public(HashMap[address, HashMap[address, uint256]])
 
 
 @deploy
-def __init__(_undyHq: address, _governance: address):
-    assert empty(address) not in [_undyHq, _governance] # dev: invalid addrs
+def __init__(_undyHq: address):
+    assert empty(address) not in [_undyHq] # dev: invalid addrs
     addys.__init__(_undyHq)
     yld.__init__(False)
-    GOVERNANCE = _governance
 
 
 @view
 @internal
 def _canMigrate(_caller: address) -> bool:
-    if _caller == GOVERNANCE:
-        return True
     return _caller == staticcall UndyHq(addys._getUndyHq()).governance()
 
 
@@ -237,7 +240,7 @@ def depositForYield(
     self.userAssets[msg.sender][_asset] += depositAmount
 
     log RecoveryDeposit(user=msg.sender, asset=_asset, amount=depositAmount)
-    return depositAmount, empty(address), 0, 0
+    return depositAmount, empty(address), 0, 1
 
 
 @external
@@ -258,6 +261,10 @@ def migrateFunds(_recoveries: DynArray[Recovery, MAX_RECOVERIES]) -> bool:
     for r: Recovery in _recoveries:
         if empty(address) in [r.asset, r.recipient]:
             continue
+
+        assert self._isUserWallet(r.recipient) # dev: not a user wallet
+        config: address = staticcall UserWallet(r.recipient).walletConfig()
+        assert staticcall UserWalletConfig(config).indexOfManager(AGENT_WRAPPER) != 0 # dev: recipient wallet not managed by UndyHq
 
         recordedAmount: uint256 = self.userAssets[r.user][r.asset]
         if recordedAmount == 0:

--- a/contracts/legos/yield/RecoveryLego.vy
+++ b/contracts/legos/yield/RecoveryLego.vy
@@ -30,7 +30,7 @@ interface UserWallet:
     def walletConfig() -> address: view
 
 interface UserWalletConfig:
-    def indexOfManager() -> uint256: view
+    def indexOfManager(_addr: address) -> uint256: view
 
 struct Recovery:
     user: address

--- a/migration_history/base-mainnet/v1.1/2026060900-manifest.json
+++ b/migration_history/base-mainnet/v1.1/2026060900-manifest.json
@@ -1,0 +1,2978 @@
+{
+  "contracts": {
+    "RecoveryLego": {
+      "address": "0x7Ad11A75986FC96498d5244D256D101243741aEa",
+      "abi": [
+        {
+          "name": "RecoveryDeposit",
+          "inputs": [
+            {
+              "name": "user",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "FundsMigrated",
+          "inputs": [
+            {
+              "name": "user",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "recipient",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "LegoPauseModified",
+          "inputs": [
+            {
+              "name": "isPaused",
+              "type": "bool",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "LegoFundsRecovered",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "recipient",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "balance",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "SnapShotPriceConfigSet",
+          "inputs": [
+            {
+              "name": "minSnapshotDelay",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "maxNumSnapshots",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "maxUpsideDeviation",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "staleTime",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAddys",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "hq",
+                  "type": "address"
+                },
+                {
+                  "name": "undyToken",
+                  "type": "address"
+                },
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "switchboard",
+                  "type": "address"
+                },
+                {
+                  "name": "hatchery",
+                  "type": "address"
+                },
+                {
+                  "name": "lootDistributor",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                },
+                {
+                  "name": "walletBackpack",
+                  "type": "address"
+                },
+                {
+                  "name": "billing",
+                  "type": "address"
+                },
+                {
+                  "name": "vaultRegistry",
+                  "type": "address"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUndyHq",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isLegoAsset",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAssetOpportunities",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isAssetOpportunity",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getNumLegoAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "pause",
+          "inputs": [
+            {
+              "name": "_shouldPause",
+              "type": "bool"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "recoverFunds",
+          "inputs": [
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "recoverFundsMany",
+          "inputs": [
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_assets",
+              "type": "address[]"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWeightedPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getLatestSnapshot",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_pricePerShare",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "totalSupply",
+                  "type": "uint256"
+                },
+                {
+                  "name": "pricePerShare",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setSnapShotPriceConfig",
+          "inputs": [
+            {
+              "name": "_config",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "isValidPriceConfig",
+          "inputs": [
+            {
+              "name": "_config",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "vaultToAsset",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "underlyingAsset",
+                  "type": "address"
+                },
+                {
+                  "name": "decimals",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastAveragePricePerShare",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "assetOpportunities",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "indexOfAssetOpportunity",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "numAssetOpportunities",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "assets",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "indexOfAsset",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "numAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShotData",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "lastSnapShot",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "name": "totalSupply",
+                      "type": "uint256"
+                    },
+                    {
+                      "name": "pricePerShare",
+                      "type": "uint256"
+                    },
+                    {
+                      "name": "lastUpdate",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "nextIndex",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShots",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "totalSupply",
+                  "type": "uint256"
+                },
+                {
+                  "name": "pricePerShare",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShotPriceConfig",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isPaused",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "hasCapability",
+          "inputs": [
+            {
+              "name": "_action",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getRegistries",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isYieldLego",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isDexLego",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAsset",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingBalances",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenBalance",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAmount",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAmountSafe",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenBalance",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingData",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingData",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_appraiser",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUsdValueOfVaultToken",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUsdValueOfVaultToken",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_appraiser",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isRebasing",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_decimals",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getVaultTokenAmount",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_assetAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "canRegisterVaultToken",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalAssets",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalBorrows",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUtilizationRatio",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAvailLiquidity",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isEligibleForYieldBonus",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWithdrawalFees",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "depositForYield",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "depositForYield",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "withdrawFromYield",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "withdrawFromYield",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "migrateFunds",
+          "inputs": [
+            {
+              "name": "_recoveries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "user",
+                  "type": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address"
+                },
+                {
+                  "name": "recipient",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addPriceSnapshot",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAccessForLego",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_action",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "string"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "claimIncentives",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_proofs",
+              "type": "bytes32[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "claimIncentives",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_proofs",
+              "type": "bytes32[]"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "claimRewards",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "claimRewards",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "swapTokens",
+          "inputs": [
+            {
+              "name": "_amountIn",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_tokenPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_poolPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "swapTokens",
+          "inputs": [
+            {
+              "name": "_amountIn",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_tokenPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_poolPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "mintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_tokenInAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "mintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_tokenInAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "confirmMintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "confirmMintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "borrow",
+          "inputs": [
+            {
+              "name": "_borrowAsset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "borrow",
+          "inputs": [
+            {
+              "name": "_borrowAsset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "repayDebt",
+          "inputs": [
+            {
+              "name": "_paymentAsset",
+              "type": "address"
+            },
+            {
+              "name": "_paymentAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "repayDebt",
+          "inputs": [
+            {
+              "name": "_paymentAsset",
+              "type": "address"
+            },
+            {
+              "name": "_paymentAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minLpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minLpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_lpToken",
+              "type": "address"
+            },
+            {
+              "name": "_lpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_lpToken",
+              "type": "address"
+            },
+            {
+              "name": "_lpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_tickLower",
+              "type": "int24"
+            },
+            {
+              "name": "_tickUpper",
+              "type": "int24"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_tickLower",
+              "type": "int24"
+            },
+            {
+              "name": "_tickUpper",
+              "type": "int24"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_liqToRemove",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_liqToRemove",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "userAssets",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "_undyHq",
+              "type": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "solc_json": {
+        "language": "Vyper",
+        "sources": {
+          "interfaces/WalletStructs.vyi": {
+            "content": "# @version 0.4.3\n\nflag ActionType:\n    TRANSFER\n    EARN_DEPOSIT\n    EARN_WITHDRAW\n    EARN_REBALANCE\n    SWAP\n    MINT_REDEEM\n    CONFIRM_MINT_REDEEM\n    ADD_COLLATERAL\n    REMOVE_COLLATERAL\n    BORROW\n    REPAY_DEBT\n    REWARDS\n    ETH_TO_WETH\n    WETH_TO_ETH\n    ADD_LIQ\n    REMOVE_LIQ\n    ADD_LIQ_CONC\n    REMOVE_LIQ_CONC\n    PAY_CHEQUE\n\nMAX_DELEVERAGE_WALLET_ASSETS: constant(uint256) = 10\n\nstruct DeleverageAsset:\n    vaultId: uint256\n    asset: address\n    targetRepayAmount: uint256\n\nstruct WalletAssetData:\n    assetBalance: uint256\n    usdValue: uint256\n    isYieldAsset: bool\n    lastPricePerShare: uint256\n\nstruct ActionData:\n    ledger: address\n    missionControl: address\n    legoBook: address\n    hatchery: address\n    lootDistributor: address\n    appraiser: address\n    billing: address\n    vaultRegistry: address\n    wallet: address\n    walletConfig: address\n    walletOwner: address\n    inEjectMode: bool\n    isFrozen: bool\n    lastTotalUsdValue: uint256\n    signer: address\n    isManager: bool\n    legoId: uint256\n    legoAddr: address\n    eth: address\n    weth: address\n\nstruct MiniAddys:\n    ledger: address\n    missionControl: address\n    legoBook: address\n    appraiser: address\n",
+            "sha256sum": "5e90186d7e7ab11c6a1bf0f6bba8292f6d3f07fbade6c96da6a13babdf9e6805"
+          },
+          "interfaces/LegoPartner.vyi": {
+            "content": "# @version 0.4.3\n\nfrom interfaces import WalletStructs as ws\n\nMAX_TOKEN_PATH: constant(uint256) = 5\nMAX_RECOVER_ASSETS: constant(uint256) = 20\nMAX_PROOFS: constant(uint256) = 25\n\n@external\ndef addLiquidityConcentrated(_nftTokenId: uint256, _pool: address, _tokenA: address, _tokenB: address, _tickLower: int24, _tickUpper: int24, _amountA: uint256, _amountB: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef addLiquidity(_pool: address, _tokenA: address, _tokenB: address, _amountA: uint256, _amountB: uint256, _minAmountA: uint256, _minAmountB: uint256, _minLpAmount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (address, uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef removeLiquidityConcentrated(_nftTokenId: uint256, _pool: address, _tokenA: address, _tokenB: address, _liqToRemove: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, bool, uint256):\n    ...\n\n@external\ndef removeLiquidity(_pool: address, _tokenA: address, _tokenB: address, _lpToken: address, _lpAmount: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef mintOrRedeemAsset(_tokenIn: address, _tokenOut: address, _tokenInAmount: uint256, _minAmountOut: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, bool, uint256):\n    ...\n\n@external\ndef swapTokens(_amountIn: uint256, _minAmountOut: uint256, _tokenPath: DynArray[address, MAX_TOKEN_PATH], _poolPath: DynArray[address, MAX_TOKEN_PATH - 1], _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256):\n    ...\n\n@external\ndef depositForYield(_asset: address, _amount: uint256, _vaultAddr: address, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, address, uint256, uint256):\n    ...\n\n@external\ndef withdrawFromYield(_vaultToken: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, address, uint256, uint256):\n    ...\n\n@external\ndef confirmMintOrRedeemAsset(_tokenIn: address, _tokenOut: address, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef borrow(_borrowAsset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef repayDebt(_paymentAsset: address, _paymentAmount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef claimIncentives(_user: address, _rewardToken: address, _rewardAmount: uint256, _proofs: DynArray[bytes32, MAX_PROOFS], _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef removeCollateral(_asset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef addCollateral(_asset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@view\n@external\ndef getAccessForLego(_user: address, _action: ws.ActionType) -> (address, String[64], uint256):\n    ...\n\n@view\n@external\ndef hasCapability(_action: ws.ActionType) -> bool:\n    ...\n\n@view\n@external\ndef getRegistries() -> DynArray[address, 10]:\n    ...\n\n@view\n@external\ndef isYieldLego() -> bool:\n    ...\n\n@view\n@external\ndef isDexLego() -> bool:\n    ...\n\n\n# common\n\n\n@view\n@external\ndef isPaused() -> bool:\n    ...\n\n\n@external\ndef pause(_shouldPause: bool):\n    ...\n\n\n@external\ndef recoverFunds(_recipient: address, _asset: address):\n    ...\n\n\n@external\ndef recoverFundsMany(_recipient: address, _assets: DynArray[address, 20]):\n    ...",
+            "sha256sum": "f2afb7bd72d4301aea77bbe4177b7ae954ba6f6b76af363965993eb92ad0b715"
+          },
+          "interfaces/LegoStructs.vyi": {
+            "content": "# @version 0.4.3\n\nstruct VaultTokenInfo:\n    underlyingAsset: address\n    decimals: uint256\n    lastAveragePricePerShare: uint256\n\nstruct SnapShotPriceConfig:\n    minSnapshotDelay: uint256\n    maxNumSnapshots: uint256\n    maxUpsideDeviation: uint256\n    staleTime: uint256\n\nstruct SingleSnapShot:\n    totalSupply: uint256\n    pricePerShare: uint256\n    lastUpdate: uint256\n\nstruct SnapShotData:\n    lastSnapShot: SingleSnapShot\n    nextIndex: uint256\n",
+            "sha256sum": "8ae48be17d812d57fbd671bbf0593e8abf175ad0924e47c5997823cac19ec806"
+          },
+          "interfaces/YieldLego.vyi": {
+            "content": "# @version 0.4.3\n\nfrom interfaces import LegoStructs as ls\n\n\n###################\n# Underlying Data #\n###################\n\n\n@view\n@external\ndef getUnderlyingAsset(_vaultToken: address) -> address:\n    ...\n\n\n@view\n@external\ndef getUnderlyingBalances(_vaultToken: address, _vaultTokenBalance: uint256) -> (uint256, uint256):\n    ...\n\n\n@view\n@external\ndef getUnderlyingAmount(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUnderlyingAmountSafe(_vaultToken: address, _vaultTokenBalance: uint256) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUnderlyingData(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> (address, uint256, uint256):\n    ...\n\n\n@view\n@external\ndef getUsdValueOfVaultToken(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> uint256:\n    ...\n\n\n###############\n# Other Utils #\n###############\n\n\n@view\n@external\ndef isRebasing() -> bool:\n    ...\n\n\n@view\n@external\ndef getPricePerShare(_vaultToken: address, _decimals: uint256 = 0) -> uint256:\n    ...\n\n\n@view\n@external\ndef getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef canRegisterVaultToken(_asset: address, _vaultToken: address) -> bool:\n    ...\n\n\n@view\n@external\ndef totalAssets(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef totalBorrows(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUtilizationRatio(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getAvailLiquidity(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef isEligibleForYieldBonus(_asset: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getWithdrawalFees(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    ...\n\n\n###################\n# Yield Lego Data #\n###################\n\n\n@view\n@external\ndef isLegoAsset(_asset: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getAssetOpportunities(_asset: address) -> DynArray[address, 40]:\n    ...\n\n\n@view\n@external\ndef getAssets() -> DynArray[address, 20]:\n    ...\n\n\n@view\n@external\ndef isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getNumLegoAssets() -> uint256:\n    ...\n\n\n@view\n@external\ndef assets(_index: uint256) -> address:\n    ...\n\n\n@view\n@external\ndef indexOfAsset(_asset: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef numAssets() -> uint256:\n    ...\n\n\n@view\n@external\ndef assetOpportunities(_asset: address, _index: uint256) -> address:\n    ...\n\n\n@view\n@external\ndef indexOfAssetOpportunity(_asset: address, _vaultAddr: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef numAssetOpportunities(_asset: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef vaultToAsset(_vaultAddr: address) -> ls.VaultTokenInfo:\n    ...\n\n\n# price snapshots\n\n\n@external\ndef addPriceSnapshot(_vaultToken: address) -> bool:\n    ...\n\n\n@view\n@external\ndef snapShotPriceConfig() -> ls.SnapShotPriceConfig:\n    ...\n\n\n@view\n@external\ndef snapShotData(_vaultToken: address) -> ls.SnapShotData:\n    ...\n\n\n@view\n@external\ndef snapShots(_vaultToken: address, _index: uint256) -> ls.SingleSnapShot:\n    ...\n\n\n@view\n@external\ndef getWeightedPricePerShare(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getLatestSnapshot(_vaultToken: address, _pricePerShare: uint256) -> ls.SingleSnapShot:\n    ...\n\n\n@external\ndef setSnapShotPriceConfig(_config: ls.SnapShotPriceConfig):\n    ...\n",
+            "sha256sum": "db91c139f6018f5218b389d08c8703bc16fb994aa948805dbfea27e072f382ec"
+          },
+          "contracts/modules/Addys.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\ninterface UndyHq:\n    def isValidAddr(_addr: address) -> bool: view\n    def getAddr(_regId: uint256) -> address: view\n    def undyToken() -> address: view\n\ninterface Switchboard:\n    def isSwitchboardAddr(_addr: address) -> bool: view\n\ninterface LegoBook:\n    def isLegoAddr(_addr: address) -> bool: view\n\nstruct Addys:\n    hq: address\n    undyToken: address\n    ledger: address\n    missionControl: address\n    legoBook: address\n    switchboard: address\n    hatchery: address\n    lootDistributor: address\n    appraiser: address\n    walletBackpack: address\n    billing: address\n    vaultRegistry: address\n\n# hq\nUNDY_HQ_FOR_ADDYS: immutable(address)\n\n# core addys\nLEDGER_ID: constant(uint256) = 1\nMISSION_CONTROL_ID: constant(uint256) = 2\nLEGO_BOOK_ID: constant(uint256) = 3\nSWITCHBOARD_ID: constant(uint256) = 4\nHATCHERY_ID: constant(uint256) = 5\nLOOT_DISTRIBUTOR_ID: constant(uint256) = 6\nAPPRAISER_ID: constant(uint256) = 7\nWALLET_BACKPACK_ID: constant(uint256) = 8\nBILLING_ID: constant(uint256) = 9\nVAULT_REGISTRY_ID: constant(uint256) = 10\nHELPERS_ID: constant(uint256) = 11\n\n\n@deploy\ndef __init__(_undyHq: address):\n    assert _undyHq != empty(address) # dev: invalid undy hq\n    UNDY_HQ_FOR_ADDYS = _undyHq\n\n\n########\n# Core #\n########\n\n\n@view\n@external\ndef getAddys() -> Addys:\n    return self._generateAddys()\n\n\n@view\n@internal\ndef _getAddys(_addys: Addys = empty(Addys)) -> Addys:\n    if _addys.hq != empty(address):\n        return _addys\n    return self._generateAddys()\n\n\n@view\n@internal\ndef _generateAddys() -> Addys:\n    hq: address = UNDY_HQ_FOR_ADDYS\n    return Addys(\n        hq = hq,\n        undyToken = staticcall UndyHq(hq).undyToken(),\n        ledger = staticcall UndyHq(hq).getAddr(LEDGER_ID),\n        missionControl = staticcall UndyHq(hq).getAddr(MISSION_CONTROL_ID),\n        legoBook = staticcall UndyHq(hq).getAddr(LEGO_BOOK_ID),\n        switchboard = staticcall UndyHq(hq).getAddr(SWITCHBOARD_ID),\n        hatchery = staticcall UndyHq(hq).getAddr(HATCHERY_ID),\n        lootDistributor = staticcall UndyHq(hq).getAddr(LOOT_DISTRIBUTOR_ID),\n        appraiser = staticcall UndyHq(hq).getAddr(APPRAISER_ID),\n        walletBackpack = staticcall UndyHq(hq).getAddr(WALLET_BACKPACK_ID),\n        billing = staticcall UndyHq(hq).getAddr(BILLING_ID),\n        vaultRegistry = staticcall UndyHq(hq).getAddr(VAULT_REGISTRY_ID),\n    )\n\n\n##########\n# Tokens #\n##########\n\n\n@view\n@internal\ndef _getUndyToken() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).undyToken()\n\n\n###########\n# Helpers #\n###########\n\n\n# undy hq\n\n\n@view\n@external\ndef getUndyHq() -> address:\n    return self._getUndyHq()\n\n\n@view\n@internal\ndef _getUndyHq() -> address:\n    return UNDY_HQ_FOR_ADDYS\n\n\n# utils\n\n\n@view\n@internal\ndef _isValidUndyAddr(_addr: address, _hq: address = empty(address)) -> bool:\n    hq: address = _hq\n    if _hq == empty(address):\n        hq = UNDY_HQ_FOR_ADDYS\n    \n    # core departments\n    if staticcall UndyHq(hq).isValidAddr(_addr):\n        return True\n\n    # lego book\n    legoBook: address = staticcall UndyHq(hq).getAddr(LEGO_BOOK_ID)\n    if legoBook != empty(address) and staticcall LegoBook(legoBook).isLegoAddr(_addr):\n        return True\n\n    # switchboard config\n    switchboard: address = staticcall UndyHq(hq).getAddr(SWITCHBOARD_ID)\n    if switchboard != empty(address) and staticcall Switchboard(switchboard).isSwitchboardAddr(_addr):\n        return True\n\n    return False\n\n\n@view\n@internal\ndef _isSwitchboardAddr(_addr: address) -> bool:\n    switchboard: address = staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(SWITCHBOARD_ID)\n    if switchboard == empty(address):\n        return False\n    return staticcall Switchboard(switchboard).isSwitchboardAddr(_addr)\n\n\n@view\n@internal\ndef _isLegoBookAddr(_addr: address) -> bool:\n    legoBook: address = staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEGO_BOOK_ID)\n    if legoBook == empty(address):\n        return False\n    return staticcall LegoBook(legoBook).isLegoAddr(_addr)\n\n\n###############\n# Departments #\n###############\n\n\n# ledger\n\n\n@pure\n@internal\ndef _getLedgerId() -> uint256:\n    return LEDGER_ID\n\n\n@view\n@internal\ndef _getLedgerAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEDGER_ID)\n\n\n# mission control\n\n\n@pure\n@internal\ndef _getMissionControlId() -> uint256:\n    return MISSION_CONTROL_ID\n\n\n@view\n@internal\ndef _getMissionControlAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(MISSION_CONTROL_ID)\n\n\n# lego book\n\n\n@pure\n@internal\ndef _getLegoBookId() -> uint256:\n    return LEGO_BOOK_ID\n\n\n@view\n@internal\ndef _getLegoBookAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEGO_BOOK_ID)\n\n\n# switchboard\n\n\n@pure\n@internal\ndef _getSwitchboardId() -> uint256:\n    return SWITCHBOARD_ID\n\n\n@view\n@internal\ndef _getSwitchboardAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(SWITCHBOARD_ID)\n\n\n# hatchery\n\n\n@pure\n@internal\ndef _getHatcheryId() -> uint256:\n    return HATCHERY_ID\n\n\n@view\n@internal\ndef _getHatcheryAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(HATCHERY_ID)\n\n\n# loot distributor\n\n\n@pure\n@internal\ndef _getLootDistributorId() -> uint256:\n    return LOOT_DISTRIBUTOR_ID\n\n\n@view\n@internal\ndef _getLootDistributorAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LOOT_DISTRIBUTOR_ID)\n\n\n# appraiser\n\n\n@pure\n@internal\ndef _getAppraiserId() -> uint256:\n    return APPRAISER_ID\n\n\n@view\n@internal\ndef _getAppraiserAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(APPRAISER_ID)\n\n\n# wallet backpack\n\n\n@pure\n@internal\ndef _getWalletBackpackId() -> uint256:\n    return WALLET_BACKPACK_ID\n\n\n@view\n@internal\ndef _getWalletBackpackAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(WALLET_BACKPACK_ID)\n\n\n# billing\n\n\n@pure\n@internal\ndef _getBillingId() -> uint256:\n    return BILLING_ID\n\n\n@view\n@internal\ndef _getBillingAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(BILLING_ID)\n\n\n# vault registry\n\n\n@pure\n@internal\ndef _getVaultRegistryId() -> uint256:\n    return VAULT_REGISTRY_ID\n\n\n@view\n@internal\ndef _getVaultRegistryAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(VAULT_REGISTRY_ID)\n\n\n# helpers\n\n\n@pure\n@internal\ndef _getHelpersId() -> uint256:\n    return HELPERS_ID\n\n\n@view\n@internal\ndef _getHelpersAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(HELPERS_ID)",
+            "sha256sum": "88810adecf303cb2dc8761f5370469808ecb3c5daccfd4ddce46338c7baa2acc"
+          },
+          "contracts/modules/YieldLegoData.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\nuses: addys\n\nimport contracts.modules.Addys as addys\n\nfrom interfaces import WalletStructs as ws\nfrom interfaces import LegoStructs as ls\nfrom ethereum.ercs import IERC20\nfrom ethereum.ercs import IERC20Detailed\n\nevent AssetOpportunityAdded:\n    asset: indexed(address)\n    vaultAddr: indexed(address)\n\nevent AssetOpportunityRemoved:\n    asset: indexed(address)\n    vaultAddr: indexed(address)\n\nevent LegoPauseModified:\n    isPaused: bool\n\nevent LegoFundsRecovered:\n    asset: indexed(address)\n    recipient: indexed(address)\n    balance: uint256\n\nevent PricePerShareSnapShotAdded:\n    vaultToken: indexed(address)\n    totalSupply: uint256\n    pricePerShare: uint256\n    lastAveragePricePerShare: uint256\n\nevent SnapShotPriceConfigSet:\n    minSnapshotDelay: uint256\n    maxNumSnapshots: uint256\n    maxUpsideDeviation: uint256\n    staleTime: uint256\n\n# core\nvaultToAsset: public(HashMap[address, ls.VaultTokenInfo]) # vault addr -> data\n\n# asset opportunities\nassetOpportunities: public(HashMap[address, HashMap[uint256, address]]) # asset -> index -> vault addr\nindexOfAssetOpportunity: public(HashMap[address, HashMap[address, uint256]]) # asset -> vault addr -> index\nnumAssetOpportunities: public(HashMap[address, uint256]) # asset -> number of opportunities\n\n# lego assets (iterable)\nassets: public(HashMap[uint256, address]) # index -> asset\nindexOfAsset: public(HashMap[address, uint256]) # asset -> index\nnumAssets: public(uint256) # num assets\n\n# price snapshots\nsnapShotData: public(HashMap[address, ls.SnapShotData]) # vault token -> data\nsnapShots: public(HashMap[address, HashMap[uint256, ls.SingleSnapShot]]) # vault token -> index -> snapshot\nsnapShotPriceConfig: public(ls.SnapShotPriceConfig) # config\n\nisPaused: public(bool)\n\nMAX_VAULTS: constant(uint256) = 40\nMAX_ASSETS: constant(uint256) = 20\nMAX_RECOVER_ASSETS: constant(uint256) = 20\nONE_DAY_SECONDS: constant(uint256) = 60 * 60 * 24\nONE_WEEK_SECONDS: constant(uint256) = ONE_DAY_SECONDS * 7\nHUNDRED_PERCENT: constant(uint256) = 100_00\n\n\n@deploy\ndef __init__(_shouldPause: bool):\n    self.isPaused = _shouldPause\n    self.numAssets = 1 # not using 0 index\n\n    # default snapshot price config\n    self.snapShotPriceConfig = ls.SnapShotPriceConfig(\n        minSnapshotDelay = 60 * 10, # 10 minutes\n        maxNumSnapshots = 20,\n        maxUpsideDeviation = 10_00, # 10%\n        staleTime = ONE_DAY_SECONDS, # 1 day\n    )\n\n\n#########\n# Views #\n#########\n\n\n# is lego asset\n\n\n@view\n@external\ndef isLegoAsset(_asset: address) -> bool:\n    return self._isLegoAsset(_asset)\n\n\n@view\n@internal\ndef _isLegoAsset(_asset: address) -> bool:\n    return self.indexOfAsset[_asset] != 0\n\n\n# vault opportunities\n\n\n@view\n@external\ndef getAssetOpportunities(_asset: address) -> DynArray[address, MAX_VAULTS]:\n    numOpportunities: uint256 = self.numAssetOpportunities[_asset]\n    if numOpportunities == 0:\n        return []\n    opportunities: DynArray[address, MAX_VAULTS] = []\n    for i: uint256 in range(1, numOpportunities, bound=MAX_VAULTS):\n        opportunities.append(self.assetOpportunities[_asset][i])\n    return opportunities\n\n\n# all assets registered\n\n\n@view\n@external\ndef getAssets() -> DynArray[address, MAX_ASSETS]:\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return []\n    assets: DynArray[address, MAX_ASSETS] = []\n    for i: uint256 in range(1, numAssets, bound=MAX_ASSETS):\n        assets.append(self.assets[i])\n    return assets\n\n\n################\n# Registration #\n################\n\n\n@view\n@external\ndef isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    return self._isAssetOpportunity(_asset, _vaultAddr)\n\n\n@view\n@internal\ndef _isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    return self.indexOfAssetOpportunity[_asset][_vaultAddr] != 0\n\n\n# add asset opportunity\n\n\n@internal\ndef _addAssetOpportunity(_asset: address, _vaultAddr: address) -> ls.VaultTokenInfo:\n    if self.indexOfAssetOpportunity[_asset][_vaultAddr] != 0:\n        return self.vaultToAsset[_vaultAddr]\n\n    if empty(address) in [_asset, _vaultAddr]:\n        return empty(ls.VaultTokenInfo)\n\n    # add asset opportunity\n    aid: uint256 = self.numAssetOpportunities[_asset]\n    if aid == 0:\n        aid = 1 # not using 0 index\n    self.assetOpportunities[_asset][aid] = _vaultAddr\n    self.indexOfAssetOpportunity[_asset][_vaultAddr] = aid\n    self.numAssetOpportunities[_asset] = aid + 1\n\n    # add mapping\n    vaultInfo: ls.VaultTokenInfo = ls.VaultTokenInfo(\n        underlyingAsset = _asset,\n        decimals = convert(staticcall IERC20Detailed(_vaultAddr).decimals(), uint256),\n        lastAveragePricePerShare = 0,\n    )\n    self.vaultToAsset[_vaultAddr] = vaultInfo\n\n    # add asset\n    self._addAsset(_asset)\n\n    log AssetOpportunityAdded(asset=_asset, vaultAddr=_vaultAddr)\n    return vaultInfo\n\n\n# remove asset opportunity\n\n\n@internal\ndef _removeAssetOpportunity(_asset: address, _vaultAddr: address):\n    numOpportunities: uint256 = self.numAssetOpportunities[_asset]\n    if numOpportunities == 0:\n        return\n\n    targetIndex: uint256 = self.indexOfAssetOpportunity[_asset][_vaultAddr]\n    if targetIndex == 0:\n        return\n\n    # update data\n    lastIndex: uint256 = numOpportunities - 1\n    self.numAssetOpportunities[_asset] = lastIndex\n    self.indexOfAssetOpportunity[_asset][_vaultAddr] = 0\n\n    self.vaultToAsset[_vaultAddr] = empty(ls.VaultTokenInfo)\n\n    # clear all snapshot data for the vault token to prevent contamination on re-add\n    self.snapShotData[_vaultAddr] = empty(ls.SnapShotData)\n\n    # clear all historical snapshots\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    for i: uint256 in range(config.maxNumSnapshots, bound=max_value(uint256)):\n        if i >= config.maxNumSnapshots:\n            break\n        self.snapShots[_vaultAddr][i] = empty(ls.SingleSnapShot)\n\n    # shift to replace the removed one\n    if targetIndex != lastIndex:\n        lastVaultAddr: address = self.assetOpportunities[_asset][lastIndex]\n        self.assetOpportunities[_asset][targetIndex] = lastVaultAddr\n        self.indexOfAssetOpportunity[_asset][lastVaultAddr] = targetIndex\n\n    # remove asset\n    if lastIndex <= 1:\n        self._removeAsset(_asset)\n\n    log AssetOpportunityRemoved(asset=_asset, vaultAddr=_vaultAddr)\n\n\n# add asset\n\n\n@internal\ndef _addAsset(_asset: address):\n    if self.indexOfAsset[_asset] != 0:\n        return\n\n    aid: uint256 = self.numAssets\n    if aid == 0:\n        aid = 1 # not using 0 index\n    self.assets[aid] = _asset\n    self.indexOfAsset[_asset] = aid\n    self.numAssets = aid + 1\n\n\n# remove asset\n\n\n@internal\ndef _removeAsset(_asset: address):\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return\n\n    targetIndex: uint256 = self.indexOfAsset[_asset]\n    if targetIndex == 0:\n        return\n\n    # update data\n    lastIndex: uint256 = numAssets - 1\n    self.numAssets = lastIndex\n    self.indexOfAsset[_asset] = 0\n\n    # shift to replace the removed one\n    if targetIndex != lastIndex:\n        lastAsset: address = self.assets[lastIndex]\n        self.assets[targetIndex] = lastAsset\n        self.indexOfAsset[lastAsset] = targetIndex\n\n\n# num lego assets (true number, use `numAssets` for iteration)\n\n\n@view\n@external\ndef getNumLegoAssets() -> uint256:\n    return self._getNumLegoAssets()\n\n\n@view\n@internal\ndef _getNumLegoAssets() -> uint256:\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return 0\n    return numAssets - 1\n\n\n###########\n# General #\n###########\n\n\n# fill mini addys\n\n\n@view\n@internal\ndef _getMiniAddys(_miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> ws.MiniAddys:\n    if _miniAddys.ledger != empty(address):\n        return _miniAddys\n    return ws.MiniAddys(\n        ledger = addys._getLedgerAddr(),\n        missionControl = addys._getMissionControlAddr(),\n        legoBook = addys._getLegoBookAddr(),\n        appraiser = addys._getAppraiserAddr(),\n    )\n\n\n# activate\n\n\n@external\ndef pause(_shouldPause: bool):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    assert _shouldPause != self.isPaused # dev: no change\n    self.isPaused = _shouldPause\n    log LegoPauseModified(isPaused=_shouldPause)\n\n\n# recover funds\n\n\n@external\ndef recoverFunds(_recipient: address, _asset: address):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    self._recoverFunds(_recipient, _asset)\n\n\n@external\ndef recoverFundsMany(_recipient: address, _assets: DynArray[address, MAX_RECOVER_ASSETS]):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    for a: address in _assets:\n        self._recoverFunds(_recipient, a)\n\n\n@internal\ndef _recoverFunds(_recipient: address, _asset: address):\n    assert empty(address) not in [_recipient, _asset] # dev: invalid recipient or asset\n    balance: uint256 = staticcall IERC20(_asset).balanceOf(self)\n    assert balance != 0 # dev: nothing to recover\n\n    assert extcall IERC20(_asset).transfer(_recipient, balance, default_return_value=True) # dev: recovery failed\n    log LegoFundsRecovered(asset=_asset, recipient=_recipient, balance=balance)\n\n\n###################\n# Price Snapshots #\n###################\n\n\n# add price snapshot\n\n\n@internal\ndef _addPriceSnapshot(_vaultToken: address, _pricePerShare: uint256, _vaultTokenDecimals: uint256) -> bool:\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    if config.maxNumSnapshots == 0:\n        return False\n\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n\n    # already have snapshot for this time\n    if data.lastSnapShot.lastUpdate == block.timestamp:\n        return False\n\n    # check if snapshot is too recent\n    if data.lastSnapShot.lastUpdate + config.minSnapshotDelay > block.timestamp:\n        return False\n\n    # create and store new snapshot\n    newSnapshot: ls.SingleSnapShot = self._getLatestSnapshot(_vaultToken, _pricePerShare, _vaultTokenDecimals, data.lastSnapShot, config)\n    data.lastSnapShot = newSnapshot\n    self.snapShots[_vaultToken][data.nextIndex] = newSnapshot\n\n    # update index\n    data.nextIndex += 1\n    if data.nextIndex >= config.maxNumSnapshots:\n        data.nextIndex = 0\n\n    # save snap shot data\n    self.snapShotData[_vaultToken] = data\n\n    # update cached weighted average price per share\n    lastAveragePricePerShare: uint256 = self._getWeightedPricePerShare(_vaultToken, _pricePerShare)\n    self.vaultToAsset[_vaultToken].lastAveragePricePerShare = lastAveragePricePerShare\n\n    log PricePerShareSnapShotAdded(\n        vaultToken = _vaultToken,\n        totalSupply = newSnapshot.totalSupply,\n        pricePerShare = newSnapshot.pricePerShare,\n        lastAveragePricePerShare = lastAveragePricePerShare,\n    )\n    return True\n\n\n# weighted price per share\n\n\n@view\n@external\ndef getWeightedPricePerShare(_vaultToken: address) -> uint256:\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n    return self._getWeightedPricePerShare(_vaultToken, data.lastSnapShot.pricePerShare)\n\n\n@view\n@internal\ndef _getWeightedPricePerShare(_vaultToken: address, _lastPricePerShare: uint256) -> uint256:\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    if config.maxNumSnapshots == 0:\n        return 0\n\n    # calculate weighted average price using all valid snapshots\n    numerator: uint256 = 0\n    denominator: uint256 = 0\n    for i: uint256 in range(config.maxNumSnapshots, bound=max_value(uint256)):\n\n        snapShot: ls.SingleSnapShot = self.snapShots[_vaultToken][i]\n        if snapShot.pricePerShare == 0 or snapShot.totalSupply == 0 or snapShot.lastUpdate == 0:\n            continue\n\n        # too stale, skip\n        if config.staleTime != 0 and block.timestamp > snapShot.lastUpdate + config.staleTime:\n            continue\n\n        numerator += (snapShot.totalSupply * snapShot.pricePerShare)\n        denominator += snapShot.totalSupply\n\n    # weighted price per share\n    weightedPricePerShare: uint256 = 0\n    if numerator != 0:\n        weightedPricePerShare = numerator // denominator\n    else:\n        weightedPricePerShare = _lastPricePerShare\n\n    return weightedPricePerShare\n\n\n# latest snapshot\n\n\n@view\n@external\ndef getLatestSnapshot(_vaultToken: address, _pricePerShare: uint256) -> ls.SingleSnapShot:\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    vaultTokenDecimals: uint256 = self.vaultToAsset[_vaultToken].decimals\n    return self._getLatestSnapshot(_vaultToken, _pricePerShare, vaultTokenDecimals, data.lastSnapShot, config)\n\n\n@view\n@internal\ndef _getLatestSnapshot(\n    _vaultToken: address,\n    _pricePerShare: uint256,\n    _vaultTokenDecimals: uint256,\n    _lastSnapShot: ls.SingleSnapShot,\n    _config: ls.SnapShotPriceConfig,\n) -> ls.SingleSnapShot:\n\n    # total supply (adjusted)\n    totalSupply: uint256 = staticcall IERC20(_vaultToken).totalSupply() // (10 ** _vaultTokenDecimals)\n    if totalSupply == 0:\n        totalSupply = 1\n\n    # throttle upside (extra safety check)\n    pricePerShare: uint256 = self._throttleUpside(_pricePerShare, _lastSnapShot.pricePerShare, _config.maxUpsideDeviation)\n\n    return ls.SingleSnapShot(\n        totalSupply = totalSupply,\n        pricePerShare = pricePerShare,\n        lastUpdate = block.timestamp,\n    )\n\n\n@pure\n@internal\ndef _throttleUpside(_newValue: uint256, _prevValue: uint256, _maxUpside: uint256) -> uint256:\n    if _maxUpside == 0 or _prevValue == 0 or _newValue == 0:\n        return _newValue\n    maxPricePerShare: uint256 = _prevValue + (_prevValue * _maxUpside // HUNDRED_PERCENT)\n    return min(_newValue, maxPricePerShare)\n\n\n# snapshot price config\n\n\n@external\ndef setSnapShotPriceConfig(_config: ls.SnapShotPriceConfig):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    assert self._isValidPriceConfig(_config) # dev: invalid config\n    self.snapShotPriceConfig = _config\n    log SnapShotPriceConfigSet(\n        minSnapshotDelay=_config.minSnapshotDelay,\n        maxNumSnapshots=_config.maxNumSnapshots,\n        maxUpsideDeviation=_config.maxUpsideDeviation,\n        staleTime=_config.staleTime\n    )\n\n\n@pure\n@external\ndef isValidPriceConfig(_config: ls.SnapShotPriceConfig) -> bool:\n    return self._isValidPriceConfig(_config)\n\n\n@pure\n@internal\ndef _isValidPriceConfig(_config: ls.SnapShotPriceConfig) -> bool:\n    if _config.minSnapshotDelay > ONE_WEEK_SECONDS:\n        return False\n    if _config.maxNumSnapshots == 0 or _config.maxNumSnapshots > 25:\n        return False\n    if _config.maxUpsideDeviation > HUNDRED_PERCENT:\n        return False\n    return _config.staleTime < ONE_WEEK_SECONDS",
+            "sha256sum": "a6a22b1f8df8bc05dc2a6d10bdd7abd22abc149272255b3ac43765ca5d9a25b0"
+          },
+          "contracts/legos/yield/RecoveryLego.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\nimplements: Lego\nimplements: YieldLego\n\nexports: addys.__interface__\nexports: yld.__interface__\n\ninitializes: addys\ninitializes: yld[addys := addys]\n\nfrom interfaces import LegoPartner as Lego\nfrom interfaces import YieldLego as YieldLego\nfrom interfaces import WalletStructs as ws\n\nimport contracts.modules.Addys as addys\nimport contracts.modules.YieldLegoData as yld\n\nfrom ethereum.ercs import IERC20\n\ninterface UndyHq:\n    def governance() -> address: view\n\ninterface Ledger:\n    def isUserWallet(_user: address) -> bool: view\n\ninterface UserWallet:\n    def walletConfig() -> address: view\n\ninterface UserWalletConfig:\n    def indexOfManager(_addr: address) -> uint256: view\n\nstruct Recovery:\n    user: address\n    asset: address\n    recipient: address\n\nevent RecoveryDeposit:\n    user: indexed(address)\n    asset: indexed(address)\n    amount: uint256\n\nevent FundsMigrated:\n    user: indexed(address)\n    asset: indexed(address)\n    recipient: indexed(address)\n    amount: uint256\n\nMAX_TOKEN_PATH: constant(uint256) = 5\nMAX_PROOFS: constant(uint256) = 25\nMAX_RECOVERIES: constant(uint256) = 30\n\nAGENT_WRAPPER: constant(address) = 0x8ee401f1E0F4CC0Ed57318AB6dAab1F1Fb59f65f\n\n# user -> asset -> amount\nuserAssets: public(HashMap[address, HashMap[address, uint256]])\n\n\n@deploy\ndef __init__(_undyHq: address):\n    assert empty(address) not in [_undyHq] # dev: invalid addrs\n    addys.__init__(_undyHq)\n    yld.__init__(False)\n\n\n@view\n@internal\ndef _canMigrate(_caller: address) -> bool:\n    return _caller == staticcall UndyHq(addys._getUndyHq()).governance()\n\n\n@view\n@internal\ndef _isUserWallet(_wallet: address) -> bool:\n    ledger: address = addys._getLedgerAddr()\n    if ledger == empty(address):\n        return False\n    return staticcall Ledger(ledger).isUserWallet(_wallet)\n\n\n#########\n# Views #\n#########\n\n\n@view\n@external\ndef hasCapability(_action: ws.ActionType) -> bool:\n    return _action == ws.ActionType.EARN_DEPOSIT\n\n\n@view\n@external\ndef getRegistries() -> DynArray[address, 10]:\n    return []\n\n\n@view\n@external\ndef isYieldLego() -> bool:\n    return True\n\n\n@view\n@external\ndef isDexLego() -> bool:\n    return False\n\n\n###################\n# Underlying Data #\n###################\n\n\n@view\n@external\ndef getUnderlyingAsset(_vaultToken: address) -> address:\n    return empty(address)\n\n\n@view\n@external\ndef getUnderlyingBalances(_vaultToken: address, _vaultTokenBalance: uint256) -> (uint256, uint256):\n    return 0, 0\n\n\n@view\n@external\ndef getUnderlyingAmount(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUnderlyingAmountSafe(_vaultToken: address, _vaultTokenBalance: uint256) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUnderlyingData(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> (address, uint256, uint256):\n    return empty(address), 0, 0\n\n\n@view\n@external\ndef getUsdValueOfVaultToken(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> uint256:\n    return 0\n\n\n###############\n# Other Utils #\n###############\n\n\n@view\n@external\ndef isRebasing() -> bool:\n    return False\n\n\n@view\n@external\ndef getPricePerShare(_vaultToken: address, _decimals: uint256 = 0) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef canRegisterVaultToken(_asset: address, _vaultToken: address) -> bool:\n    return False\n\n\n@view\n@external\ndef totalAssets(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef totalBorrows(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUtilizationRatio(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getAvailLiquidity(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef isEligibleForYieldBonus(_asset: address) -> bool:\n    return False\n\n\n@view\n@external\ndef getWithdrawalFees(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    return 0\n\n\n#################\n# Yield Actions #\n#################\n\n\n@external\ndef depositForYield(\n    _asset: address,\n    _amount: uint256,\n    _vaultAddr: address,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, address, uint256, uint256):\n    assert not yld.isPaused # dev: paused\n    assert self._isUserWallet(msg.sender) # dev: not a user wallet\n    assert _asset != empty(address) # dev: invalid asset\n\n    depositAmount: uint256 = min(_amount, staticcall IERC20(_asset).balanceOf(msg.sender))\n    assert depositAmount != 0 # dev: nothing to transfer\n    assert extcall IERC20(_asset).transferFrom(msg.sender, self, depositAmount, default_return_value=True) # dev: transfer failed\n\n    self.userAssets[msg.sender][_asset] += depositAmount\n\n    log RecoveryDeposit(user=msg.sender, asset=_asset, amount=depositAmount)\n    return depositAmount, empty(address), 0, 1\n\n\n@external\ndef withdrawFromYield(\n    _vaultToken: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, address, uint256, uint256):\n    return 0, empty(address), 0, 0\n\n\n@external\ndef migrateFunds(_recoveries: DynArray[Recovery, MAX_RECOVERIES]) -> bool:\n    assert self._canMigrate(msg.sender) # dev: no perms\n\n    for r: Recovery in _recoveries:\n        if empty(address) in [r.asset, r.recipient]:\n            continue\n\n        assert self._isUserWallet(r.recipient) # dev: not a user wallet\n        config: address = staticcall UserWallet(r.recipient).walletConfig()\n        assert staticcall UserWalletConfig(config).indexOfManager(AGENT_WRAPPER) != 0 # dev: recipient wallet not managed by UndyHq\n\n        recordedAmount: uint256 = self.userAssets[r.user][r.asset]\n        if recordedAmount == 0:\n            continue\n\n        amount: uint256 = min(recordedAmount, staticcall IERC20(r.asset).balanceOf(self))\n        if amount == 0:\n            continue\n\n        self.userAssets[r.user][r.asset] = recordedAmount - amount\n        assert extcall IERC20(r.asset).transfer(r.recipient, amount, default_return_value=True) # dev: transfer failed\n        log FundsMigrated(user=r.user, asset=r.asset, recipient=r.recipient, amount=amount)\n\n    return True\n\n\n@external\ndef addPriceSnapshot(_vaultToken: address) -> bool:\n    return False\n\n\n#########\n# Other #\n#########\n\n\n@view\n@external\ndef getAccessForLego(_user: address, _action: ws.ActionType) -> (address, String[64], uint256):\n    return empty(address), empty(String[64]), 0\n\n\n@external\ndef claimIncentives(\n    _user: address,\n    _rewardToken: address,\n    _rewardAmount: uint256,\n    _proofs: DynArray[bytes32, MAX_PROOFS],\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@pure\n@external\ndef claimRewards(\n    _user: address,\n    _rewardToken: address,\n    _rewardAmount: uint256,\n    _extraData: bytes32,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef swapTokens(\n    _amountIn: uint256,\n    _minAmountOut: uint256,\n    _tokenPath: DynArray[address, MAX_TOKEN_PATH],\n    _poolPath: DynArray[address, MAX_TOKEN_PATH - 1],\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256):\n    return 0, 0, 0\n\n\n@external\ndef mintOrRedeemAsset(\n    _tokenIn: address,\n    _tokenOut: address,\n    _tokenInAmount: uint256,\n    _minAmountOut: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, bool, uint256):\n    return 0, 0, False, 0\n\n\n@external\ndef confirmMintOrRedeemAsset(\n    _tokenIn: address,\n    _tokenOut: address,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef borrow(\n    _borrowAsset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef repayDebt(\n    _paymentAsset: address,\n    _paymentAmount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef removeCollateral(\n    _asset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef addCollateral(\n    _asset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef addLiquidity(\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _amountA: uint256,\n    _amountB: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _minLpAmount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (address, uint256, uint256, uint256, uint256):\n    return empty(address), 0, 0, 0, 0\n\n\n@external\ndef removeLiquidity(\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _lpToken: address,\n    _lpAmount: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, uint256):\n    return 0, 0, 0, 0\n\n\n@external\ndef addLiquidityConcentrated(\n    _nftTokenId: uint256,\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _tickLower: int24,\n    _tickUpper: int24,\n    _amountA: uint256,\n    _amountB: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, uint256, uint256):\n    return 0, 0, 0, 0, 0\n\n\n@external\ndef removeLiquidityConcentrated(\n    _nftTokenId: uint256,\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _liqToRemove: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, bool, uint256):\n    return 0, 0, 0, False, 0\n",
+            "sha256sum": "5d508327db7efde65e695775db435580d843988b55513b99447d87d24caf0745"
+          }
+        },
+        "settings": {
+          "outputSelection": {
+            "contracts/legos/yield/RecoveryLego.vy": [
+              "*"
+            ]
+          },
+          "search_paths": [
+            "."
+          ]
+        },
+        "compiler_version": "v0.4.3+commit.bff19ea2",
+        "integrity": "c1c1c091c594b8fdf932a7f808ed83709b480c8a9d42010802f25361596ed126"
+      },
+      "args": "00000000000000000000000044cf3c4f000dfd76a35d03298049d37be688d6f9",
+      "file": "contracts/legos/yield/RecoveryLego.vy"
+    }
+  }
+}

--- a/migration_history/base-mainnet/v1.1/current-manifest.json
+++ b/migration_history/base-mainnet/v1.1/current-manifest.json
@@ -187133,6 +187133,2980 @@
       },
       "args": "00000000000000000000000044cf3c4f000dfd76a35d03298049d37be688d6f9000000000000000000000000f1a77e89a38843e95a1634a4eb16854d48d29709000000000000000000000000000000000000000000000000000000000000a8c0000000000000000000000000000000000000000000000000000000000013c680",
       "file": "contracts/core/agent/AgentSenderSpecialAdmin.vy"
+    },
+    "RecoveryLego": {
+      "address": "0x7Ad11A75986FC96498d5244D256D101243741aEa",
+      "abi": [
+        {
+          "name": "RecoveryDeposit",
+          "inputs": [
+            {
+              "name": "user",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "FundsMigrated",
+          "inputs": [
+            {
+              "name": "user",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "recipient",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "LegoPauseModified",
+          "inputs": [
+            {
+              "name": "isPaused",
+              "type": "bool",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "LegoFundsRecovered",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "recipient",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "name": "balance",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "name": "SnapShotPriceConfigSet",
+          "inputs": [
+            {
+              "name": "minSnapshotDelay",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "maxNumSnapshots",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "maxUpsideDeviation",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "staleTime",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false,
+          "type": "event"
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAddys",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "hq",
+                  "type": "address"
+                },
+                {
+                  "name": "undyToken",
+                  "type": "address"
+                },
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "switchboard",
+                  "type": "address"
+                },
+                {
+                  "name": "hatchery",
+                  "type": "address"
+                },
+                {
+                  "name": "lootDistributor",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                },
+                {
+                  "name": "walletBackpack",
+                  "type": "address"
+                },
+                {
+                  "name": "billing",
+                  "type": "address"
+                },
+                {
+                  "name": "vaultRegistry",
+                  "type": "address"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUndyHq",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isLegoAsset",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAssetOpportunities",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isAssetOpportunity",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getNumLegoAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "pause",
+          "inputs": [
+            {
+              "name": "_shouldPause",
+              "type": "bool"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "recoverFunds",
+          "inputs": [
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "recoverFundsMany",
+          "inputs": [
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_assets",
+              "type": "address[]"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWeightedPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getLatestSnapshot",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_pricePerShare",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "totalSupply",
+                  "type": "uint256"
+                },
+                {
+                  "name": "pricePerShare",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setSnapShotPriceConfig",
+          "inputs": [
+            {
+              "name": "_config",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "isValidPriceConfig",
+          "inputs": [
+            {
+              "name": "_config",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "vaultToAsset",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "underlyingAsset",
+                  "type": "address"
+                },
+                {
+                  "name": "decimals",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastAveragePricePerShare",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "assetOpportunities",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "indexOfAssetOpportunity",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "numAssetOpportunities",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "assets",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "indexOfAsset",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "numAssets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShotData",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "lastSnapShot",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "name": "totalSupply",
+                      "type": "uint256"
+                    },
+                    {
+                      "name": "pricePerShare",
+                      "type": "uint256"
+                    },
+                    {
+                      "name": "lastUpdate",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "nextIndex",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShots",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "totalSupply",
+                  "type": "uint256"
+                },
+                {
+                  "name": "pricePerShare",
+                  "type": "uint256"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "snapShotPriceConfig",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "minSnapshotDelay",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxNumSnapshots",
+                  "type": "uint256"
+                },
+                {
+                  "name": "maxUpsideDeviation",
+                  "type": "uint256"
+                },
+                {
+                  "name": "staleTime",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isPaused",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "hasCapability",
+          "inputs": [
+            {
+              "name": "_action",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getRegistries",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address[]"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isYieldLego",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isDexLego",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAsset",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingBalances",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenBalance",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAmount",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingAmountSafe",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenBalance",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingData",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUnderlyingData",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_appraiser",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUsdValueOfVaultToken",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUsdValueOfVaultToken",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_appraiser",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isRebasing",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getPricePerShare",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_decimals",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getVaultTokenAmount",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_assetAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "canRegisterVaultToken",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalAssets",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalBorrows",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getUtilizationRatio",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAvailLiquidity",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isEligibleForYieldBonus",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWithdrawalFees",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_vaultTokenAmount",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "depositForYield",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "depositForYield",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_vaultAddr",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "withdrawFromYield",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "withdrawFromYield",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "migrateFunds",
+          "inputs": [
+            {
+              "name": "_recoveries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "user",
+                  "type": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address"
+                },
+                {
+                  "name": "recipient",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addPriceSnapshot",
+          "inputs": [
+            {
+              "name": "_vaultToken",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAccessForLego",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_action",
+              "type": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "string"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "claimIncentives",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_proofs",
+              "type": "bytes32[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "claimIncentives",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_proofs",
+              "type": "bytes32[]"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "claimRewards",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "claimRewards",
+          "inputs": [
+            {
+              "name": "_user",
+              "type": "address"
+            },
+            {
+              "name": "_rewardToken",
+              "type": "address"
+            },
+            {
+              "name": "_rewardAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "swapTokens",
+          "inputs": [
+            {
+              "name": "_amountIn",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_tokenPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_poolPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "swapTokens",
+          "inputs": [
+            {
+              "name": "_amountIn",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_tokenPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_poolPath",
+              "type": "address[]"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "mintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_tokenInAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "mintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_tokenInAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "confirmMintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "confirmMintOrRedeemAsset",
+          "inputs": [
+            {
+              "name": "_tokenIn",
+              "type": "address"
+            },
+            {
+              "name": "_tokenOut",
+              "type": "address"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "borrow",
+          "inputs": [
+            {
+              "name": "_borrowAsset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "borrow",
+          "inputs": [
+            {
+              "name": "_borrowAsset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "repayDebt",
+          "inputs": [
+            {
+              "name": "_paymentAsset",
+              "type": "address"
+            },
+            {
+              "name": "_paymentAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "repayDebt",
+          "inputs": [
+            {
+              "name": "_paymentAsset",
+              "type": "address"
+            },
+            {
+              "name": "_paymentAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addCollateral",
+          "inputs": [
+            {
+              "name": "_asset",
+              "type": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minLpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minLpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_lpToken",
+              "type": "address"
+            },
+            {
+              "name": "_lpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidity",
+          "inputs": [
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_lpToken",
+              "type": "address"
+            },
+            {
+              "name": "_lpAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_tickLower",
+              "type": "int24"
+            },
+            {
+              "name": "_tickUpper",
+              "type": "int24"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_tickLower",
+              "type": "int24"
+            },
+            {
+              "name": "_tickUpper",
+              "type": "int24"
+            },
+            {
+              "name": "_amountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_amountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_liqToRemove",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeLiquidityConcentrated",
+          "inputs": [
+            {
+              "name": "_nftTokenId",
+              "type": "uint256"
+            },
+            {
+              "name": "_pool",
+              "type": "address"
+            },
+            {
+              "name": "_tokenA",
+              "type": "address"
+            },
+            {
+              "name": "_tokenB",
+              "type": "address"
+            },
+            {
+              "name": "_liqToRemove",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountA",
+              "type": "uint256"
+            },
+            {
+              "name": "_minAmountB",
+              "type": "uint256"
+            },
+            {
+              "name": "_extraData",
+              "type": "bytes32"
+            },
+            {
+              "name": "_recipient",
+              "type": "address"
+            },
+            {
+              "name": "_miniAddys",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "ledger",
+                  "type": "address"
+                },
+                {
+                  "name": "missionControl",
+                  "type": "address"
+                },
+                {
+                  "name": "legoBook",
+                  "type": "address"
+                },
+                {
+                  "name": "appraiser",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "view",
+          "type": "function",
+          "name": "userAssets",
+          "inputs": [
+            {
+              "name": "arg0",
+              "type": "address"
+            },
+            {
+              "name": "arg1",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "stateMutability": "nonpayable",
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "_undyHq",
+              "type": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "solc_json": {
+        "language": "Vyper",
+        "sources": {
+          "interfaces/WalletStructs.vyi": {
+            "content": "# @version 0.4.3\n\nflag ActionType:\n    TRANSFER\n    EARN_DEPOSIT\n    EARN_WITHDRAW\n    EARN_REBALANCE\n    SWAP\n    MINT_REDEEM\n    CONFIRM_MINT_REDEEM\n    ADD_COLLATERAL\n    REMOVE_COLLATERAL\n    BORROW\n    REPAY_DEBT\n    REWARDS\n    ETH_TO_WETH\n    WETH_TO_ETH\n    ADD_LIQ\n    REMOVE_LIQ\n    ADD_LIQ_CONC\n    REMOVE_LIQ_CONC\n    PAY_CHEQUE\n\nMAX_DELEVERAGE_WALLET_ASSETS: constant(uint256) = 10\n\nstruct DeleverageAsset:\n    vaultId: uint256\n    asset: address\n    targetRepayAmount: uint256\n\nstruct WalletAssetData:\n    assetBalance: uint256\n    usdValue: uint256\n    isYieldAsset: bool\n    lastPricePerShare: uint256\n\nstruct ActionData:\n    ledger: address\n    missionControl: address\n    legoBook: address\n    hatchery: address\n    lootDistributor: address\n    appraiser: address\n    billing: address\n    vaultRegistry: address\n    wallet: address\n    walletConfig: address\n    walletOwner: address\n    inEjectMode: bool\n    isFrozen: bool\n    lastTotalUsdValue: uint256\n    signer: address\n    isManager: bool\n    legoId: uint256\n    legoAddr: address\n    eth: address\n    weth: address\n\nstruct MiniAddys:\n    ledger: address\n    missionControl: address\n    legoBook: address\n    appraiser: address\n",
+            "sha256sum": "5e90186d7e7ab11c6a1bf0f6bba8292f6d3f07fbade6c96da6a13babdf9e6805"
+          },
+          "interfaces/LegoPartner.vyi": {
+            "content": "# @version 0.4.3\n\nfrom interfaces import WalletStructs as ws\n\nMAX_TOKEN_PATH: constant(uint256) = 5\nMAX_RECOVER_ASSETS: constant(uint256) = 20\nMAX_PROOFS: constant(uint256) = 25\n\n@external\ndef addLiquidityConcentrated(_nftTokenId: uint256, _pool: address, _tokenA: address, _tokenB: address, _tickLower: int24, _tickUpper: int24, _amountA: uint256, _amountB: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef addLiquidity(_pool: address, _tokenA: address, _tokenB: address, _amountA: uint256, _amountB: uint256, _minAmountA: uint256, _minAmountB: uint256, _minLpAmount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (address, uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef removeLiquidityConcentrated(_nftTokenId: uint256, _pool: address, _tokenA: address, _tokenB: address, _liqToRemove: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, bool, uint256):\n    ...\n\n@external\ndef removeLiquidity(_pool: address, _tokenA: address, _tokenB: address, _lpToken: address, _lpAmount: uint256, _minAmountA: uint256, _minAmountB: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256, uint256):\n    ...\n\n@external\ndef mintOrRedeemAsset(_tokenIn: address, _tokenOut: address, _tokenInAmount: uint256, _minAmountOut: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, bool, uint256):\n    ...\n\n@external\ndef swapTokens(_amountIn: uint256, _minAmountOut: uint256, _tokenPath: DynArray[address, MAX_TOKEN_PATH], _poolPath: DynArray[address, MAX_TOKEN_PATH - 1], _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256, uint256):\n    ...\n\n@external\ndef depositForYield(_asset: address, _amount: uint256, _vaultAddr: address, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, address, uint256, uint256):\n    ...\n\n@external\ndef withdrawFromYield(_vaultToken: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, address, uint256, uint256):\n    ...\n\n@external\ndef confirmMintOrRedeemAsset(_tokenIn: address, _tokenOut: address, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef borrow(_borrowAsset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef repayDebt(_paymentAsset: address, _paymentAmount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef claimIncentives(_user: address, _rewardToken: address, _rewardAmount: uint256, _proofs: DynArray[bytes32, MAX_PROOFS], _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef removeCollateral(_asset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@external\ndef addCollateral(_asset: address, _amount: uint256, _extraData: bytes32, _recipient: address, _miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> (uint256, uint256):\n    ...\n\n@view\n@external\ndef getAccessForLego(_user: address, _action: ws.ActionType) -> (address, String[64], uint256):\n    ...\n\n@view\n@external\ndef hasCapability(_action: ws.ActionType) -> bool:\n    ...\n\n@view\n@external\ndef getRegistries() -> DynArray[address, 10]:\n    ...\n\n@view\n@external\ndef isYieldLego() -> bool:\n    ...\n\n@view\n@external\ndef isDexLego() -> bool:\n    ...\n\n\n# common\n\n\n@view\n@external\ndef isPaused() -> bool:\n    ...\n\n\n@external\ndef pause(_shouldPause: bool):\n    ...\n\n\n@external\ndef recoverFunds(_recipient: address, _asset: address):\n    ...\n\n\n@external\ndef recoverFundsMany(_recipient: address, _assets: DynArray[address, 20]):\n    ...",
+            "sha256sum": "f2afb7bd72d4301aea77bbe4177b7ae954ba6f6b76af363965993eb92ad0b715"
+          },
+          "interfaces/LegoStructs.vyi": {
+            "content": "# @version 0.4.3\n\nstruct VaultTokenInfo:\n    underlyingAsset: address\n    decimals: uint256\n    lastAveragePricePerShare: uint256\n\nstruct SnapShotPriceConfig:\n    minSnapshotDelay: uint256\n    maxNumSnapshots: uint256\n    maxUpsideDeviation: uint256\n    staleTime: uint256\n\nstruct SingleSnapShot:\n    totalSupply: uint256\n    pricePerShare: uint256\n    lastUpdate: uint256\n\nstruct SnapShotData:\n    lastSnapShot: SingleSnapShot\n    nextIndex: uint256\n",
+            "sha256sum": "8ae48be17d812d57fbd671bbf0593e8abf175ad0924e47c5997823cac19ec806"
+          },
+          "interfaces/YieldLego.vyi": {
+            "content": "# @version 0.4.3\n\nfrom interfaces import LegoStructs as ls\n\n\n###################\n# Underlying Data #\n###################\n\n\n@view\n@external\ndef getUnderlyingAsset(_vaultToken: address) -> address:\n    ...\n\n\n@view\n@external\ndef getUnderlyingBalances(_vaultToken: address, _vaultTokenBalance: uint256) -> (uint256, uint256):\n    ...\n\n\n@view\n@external\ndef getUnderlyingAmount(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUnderlyingAmountSafe(_vaultToken: address, _vaultTokenBalance: uint256) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUnderlyingData(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> (address, uint256, uint256):\n    ...\n\n\n@view\n@external\ndef getUsdValueOfVaultToken(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> uint256:\n    ...\n\n\n###############\n# Other Utils #\n###############\n\n\n@view\n@external\ndef isRebasing() -> bool:\n    ...\n\n\n@view\n@external\ndef getPricePerShare(_vaultToken: address, _decimals: uint256 = 0) -> uint256:\n    ...\n\n\n@view\n@external\ndef getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef canRegisterVaultToken(_asset: address, _vaultToken: address) -> bool:\n    ...\n\n\n@view\n@external\ndef totalAssets(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef totalBorrows(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getUtilizationRatio(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getAvailLiquidity(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef isEligibleForYieldBonus(_asset: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getWithdrawalFees(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    ...\n\n\n###################\n# Yield Lego Data #\n###################\n\n\n@view\n@external\ndef isLegoAsset(_asset: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getAssetOpportunities(_asset: address) -> DynArray[address, 40]:\n    ...\n\n\n@view\n@external\ndef getAssets() -> DynArray[address, 20]:\n    ...\n\n\n@view\n@external\ndef isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    ...\n\n\n@view\n@external\ndef getNumLegoAssets() -> uint256:\n    ...\n\n\n@view\n@external\ndef assets(_index: uint256) -> address:\n    ...\n\n\n@view\n@external\ndef indexOfAsset(_asset: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef numAssets() -> uint256:\n    ...\n\n\n@view\n@external\ndef assetOpportunities(_asset: address, _index: uint256) -> address:\n    ...\n\n\n@view\n@external\ndef indexOfAssetOpportunity(_asset: address, _vaultAddr: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef numAssetOpportunities(_asset: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef vaultToAsset(_vaultAddr: address) -> ls.VaultTokenInfo:\n    ...\n\n\n# price snapshots\n\n\n@external\ndef addPriceSnapshot(_vaultToken: address) -> bool:\n    ...\n\n\n@view\n@external\ndef snapShotPriceConfig() -> ls.SnapShotPriceConfig:\n    ...\n\n\n@view\n@external\ndef snapShotData(_vaultToken: address) -> ls.SnapShotData:\n    ...\n\n\n@view\n@external\ndef snapShots(_vaultToken: address, _index: uint256) -> ls.SingleSnapShot:\n    ...\n\n\n@view\n@external\ndef getWeightedPricePerShare(_vaultToken: address) -> uint256:\n    ...\n\n\n@view\n@external\ndef getLatestSnapshot(_vaultToken: address, _pricePerShare: uint256) -> ls.SingleSnapShot:\n    ...\n\n\n@external\ndef setSnapShotPriceConfig(_config: ls.SnapShotPriceConfig):\n    ...\n",
+            "sha256sum": "db91c139f6018f5218b389d08c8703bc16fb994aa948805dbfea27e072f382ec"
+          },
+          "contracts/modules/Addys.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\ninterface UndyHq:\n    def isValidAddr(_addr: address) -> bool: view\n    def getAddr(_regId: uint256) -> address: view\n    def undyToken() -> address: view\n\ninterface Switchboard:\n    def isSwitchboardAddr(_addr: address) -> bool: view\n\ninterface LegoBook:\n    def isLegoAddr(_addr: address) -> bool: view\n\nstruct Addys:\n    hq: address\n    undyToken: address\n    ledger: address\n    missionControl: address\n    legoBook: address\n    switchboard: address\n    hatchery: address\n    lootDistributor: address\n    appraiser: address\n    walletBackpack: address\n    billing: address\n    vaultRegistry: address\n\n# hq\nUNDY_HQ_FOR_ADDYS: immutable(address)\n\n# core addys\nLEDGER_ID: constant(uint256) = 1\nMISSION_CONTROL_ID: constant(uint256) = 2\nLEGO_BOOK_ID: constant(uint256) = 3\nSWITCHBOARD_ID: constant(uint256) = 4\nHATCHERY_ID: constant(uint256) = 5\nLOOT_DISTRIBUTOR_ID: constant(uint256) = 6\nAPPRAISER_ID: constant(uint256) = 7\nWALLET_BACKPACK_ID: constant(uint256) = 8\nBILLING_ID: constant(uint256) = 9\nVAULT_REGISTRY_ID: constant(uint256) = 10\nHELPERS_ID: constant(uint256) = 11\n\n\n@deploy\ndef __init__(_undyHq: address):\n    assert _undyHq != empty(address) # dev: invalid undy hq\n    UNDY_HQ_FOR_ADDYS = _undyHq\n\n\n########\n# Core #\n########\n\n\n@view\n@external\ndef getAddys() -> Addys:\n    return self._generateAddys()\n\n\n@view\n@internal\ndef _getAddys(_addys: Addys = empty(Addys)) -> Addys:\n    if _addys.hq != empty(address):\n        return _addys\n    return self._generateAddys()\n\n\n@view\n@internal\ndef _generateAddys() -> Addys:\n    hq: address = UNDY_HQ_FOR_ADDYS\n    return Addys(\n        hq = hq,\n        undyToken = staticcall UndyHq(hq).undyToken(),\n        ledger = staticcall UndyHq(hq).getAddr(LEDGER_ID),\n        missionControl = staticcall UndyHq(hq).getAddr(MISSION_CONTROL_ID),\n        legoBook = staticcall UndyHq(hq).getAddr(LEGO_BOOK_ID),\n        switchboard = staticcall UndyHq(hq).getAddr(SWITCHBOARD_ID),\n        hatchery = staticcall UndyHq(hq).getAddr(HATCHERY_ID),\n        lootDistributor = staticcall UndyHq(hq).getAddr(LOOT_DISTRIBUTOR_ID),\n        appraiser = staticcall UndyHq(hq).getAddr(APPRAISER_ID),\n        walletBackpack = staticcall UndyHq(hq).getAddr(WALLET_BACKPACK_ID),\n        billing = staticcall UndyHq(hq).getAddr(BILLING_ID),\n        vaultRegistry = staticcall UndyHq(hq).getAddr(VAULT_REGISTRY_ID),\n    )\n\n\n##########\n# Tokens #\n##########\n\n\n@view\n@internal\ndef _getUndyToken() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).undyToken()\n\n\n###########\n# Helpers #\n###########\n\n\n# undy hq\n\n\n@view\n@external\ndef getUndyHq() -> address:\n    return self._getUndyHq()\n\n\n@view\n@internal\ndef _getUndyHq() -> address:\n    return UNDY_HQ_FOR_ADDYS\n\n\n# utils\n\n\n@view\n@internal\ndef _isValidUndyAddr(_addr: address, _hq: address = empty(address)) -> bool:\n    hq: address = _hq\n    if _hq == empty(address):\n        hq = UNDY_HQ_FOR_ADDYS\n    \n    # core departments\n    if staticcall UndyHq(hq).isValidAddr(_addr):\n        return True\n\n    # lego book\n    legoBook: address = staticcall UndyHq(hq).getAddr(LEGO_BOOK_ID)\n    if legoBook != empty(address) and staticcall LegoBook(legoBook).isLegoAddr(_addr):\n        return True\n\n    # switchboard config\n    switchboard: address = staticcall UndyHq(hq).getAddr(SWITCHBOARD_ID)\n    if switchboard != empty(address) and staticcall Switchboard(switchboard).isSwitchboardAddr(_addr):\n        return True\n\n    return False\n\n\n@view\n@internal\ndef _isSwitchboardAddr(_addr: address) -> bool:\n    switchboard: address = staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(SWITCHBOARD_ID)\n    if switchboard == empty(address):\n        return False\n    return staticcall Switchboard(switchboard).isSwitchboardAddr(_addr)\n\n\n@view\n@internal\ndef _isLegoBookAddr(_addr: address) -> bool:\n    legoBook: address = staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEGO_BOOK_ID)\n    if legoBook == empty(address):\n        return False\n    return staticcall LegoBook(legoBook).isLegoAddr(_addr)\n\n\n###############\n# Departments #\n###############\n\n\n# ledger\n\n\n@pure\n@internal\ndef _getLedgerId() -> uint256:\n    return LEDGER_ID\n\n\n@view\n@internal\ndef _getLedgerAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEDGER_ID)\n\n\n# mission control\n\n\n@pure\n@internal\ndef _getMissionControlId() -> uint256:\n    return MISSION_CONTROL_ID\n\n\n@view\n@internal\ndef _getMissionControlAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(MISSION_CONTROL_ID)\n\n\n# lego book\n\n\n@pure\n@internal\ndef _getLegoBookId() -> uint256:\n    return LEGO_BOOK_ID\n\n\n@view\n@internal\ndef _getLegoBookAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LEGO_BOOK_ID)\n\n\n# switchboard\n\n\n@pure\n@internal\ndef _getSwitchboardId() -> uint256:\n    return SWITCHBOARD_ID\n\n\n@view\n@internal\ndef _getSwitchboardAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(SWITCHBOARD_ID)\n\n\n# hatchery\n\n\n@pure\n@internal\ndef _getHatcheryId() -> uint256:\n    return HATCHERY_ID\n\n\n@view\n@internal\ndef _getHatcheryAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(HATCHERY_ID)\n\n\n# loot distributor\n\n\n@pure\n@internal\ndef _getLootDistributorId() -> uint256:\n    return LOOT_DISTRIBUTOR_ID\n\n\n@view\n@internal\ndef _getLootDistributorAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(LOOT_DISTRIBUTOR_ID)\n\n\n# appraiser\n\n\n@pure\n@internal\ndef _getAppraiserId() -> uint256:\n    return APPRAISER_ID\n\n\n@view\n@internal\ndef _getAppraiserAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(APPRAISER_ID)\n\n\n# wallet backpack\n\n\n@pure\n@internal\ndef _getWalletBackpackId() -> uint256:\n    return WALLET_BACKPACK_ID\n\n\n@view\n@internal\ndef _getWalletBackpackAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(WALLET_BACKPACK_ID)\n\n\n# billing\n\n\n@pure\n@internal\ndef _getBillingId() -> uint256:\n    return BILLING_ID\n\n\n@view\n@internal\ndef _getBillingAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(BILLING_ID)\n\n\n# vault registry\n\n\n@pure\n@internal\ndef _getVaultRegistryId() -> uint256:\n    return VAULT_REGISTRY_ID\n\n\n@view\n@internal\ndef _getVaultRegistryAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(VAULT_REGISTRY_ID)\n\n\n# helpers\n\n\n@pure\n@internal\ndef _getHelpersId() -> uint256:\n    return HELPERS_ID\n\n\n@view\n@internal\ndef _getHelpersAddr() -> address:\n    return staticcall UndyHq(UNDY_HQ_FOR_ADDYS).getAddr(HELPERS_ID)",
+            "sha256sum": "88810adecf303cb2dc8761f5370469808ecb3c5daccfd4ddce46338c7baa2acc"
+          },
+          "contracts/modules/YieldLegoData.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\nuses: addys\n\nimport contracts.modules.Addys as addys\n\nfrom interfaces import WalletStructs as ws\nfrom interfaces import LegoStructs as ls\nfrom ethereum.ercs import IERC20\nfrom ethereum.ercs import IERC20Detailed\n\nevent AssetOpportunityAdded:\n    asset: indexed(address)\n    vaultAddr: indexed(address)\n\nevent AssetOpportunityRemoved:\n    asset: indexed(address)\n    vaultAddr: indexed(address)\n\nevent LegoPauseModified:\n    isPaused: bool\n\nevent LegoFundsRecovered:\n    asset: indexed(address)\n    recipient: indexed(address)\n    balance: uint256\n\nevent PricePerShareSnapShotAdded:\n    vaultToken: indexed(address)\n    totalSupply: uint256\n    pricePerShare: uint256\n    lastAveragePricePerShare: uint256\n\nevent SnapShotPriceConfigSet:\n    minSnapshotDelay: uint256\n    maxNumSnapshots: uint256\n    maxUpsideDeviation: uint256\n    staleTime: uint256\n\n# core\nvaultToAsset: public(HashMap[address, ls.VaultTokenInfo]) # vault addr -> data\n\n# asset opportunities\nassetOpportunities: public(HashMap[address, HashMap[uint256, address]]) # asset -> index -> vault addr\nindexOfAssetOpportunity: public(HashMap[address, HashMap[address, uint256]]) # asset -> vault addr -> index\nnumAssetOpportunities: public(HashMap[address, uint256]) # asset -> number of opportunities\n\n# lego assets (iterable)\nassets: public(HashMap[uint256, address]) # index -> asset\nindexOfAsset: public(HashMap[address, uint256]) # asset -> index\nnumAssets: public(uint256) # num assets\n\n# price snapshots\nsnapShotData: public(HashMap[address, ls.SnapShotData]) # vault token -> data\nsnapShots: public(HashMap[address, HashMap[uint256, ls.SingleSnapShot]]) # vault token -> index -> snapshot\nsnapShotPriceConfig: public(ls.SnapShotPriceConfig) # config\n\nisPaused: public(bool)\n\nMAX_VAULTS: constant(uint256) = 40\nMAX_ASSETS: constant(uint256) = 20\nMAX_RECOVER_ASSETS: constant(uint256) = 20\nONE_DAY_SECONDS: constant(uint256) = 60 * 60 * 24\nONE_WEEK_SECONDS: constant(uint256) = ONE_DAY_SECONDS * 7\nHUNDRED_PERCENT: constant(uint256) = 100_00\n\n\n@deploy\ndef __init__(_shouldPause: bool):\n    self.isPaused = _shouldPause\n    self.numAssets = 1 # not using 0 index\n\n    # default snapshot price config\n    self.snapShotPriceConfig = ls.SnapShotPriceConfig(\n        minSnapshotDelay = 60 * 10, # 10 minutes\n        maxNumSnapshots = 20,\n        maxUpsideDeviation = 10_00, # 10%\n        staleTime = ONE_DAY_SECONDS, # 1 day\n    )\n\n\n#########\n# Views #\n#########\n\n\n# is lego asset\n\n\n@view\n@external\ndef isLegoAsset(_asset: address) -> bool:\n    return self._isLegoAsset(_asset)\n\n\n@view\n@internal\ndef _isLegoAsset(_asset: address) -> bool:\n    return self.indexOfAsset[_asset] != 0\n\n\n# vault opportunities\n\n\n@view\n@external\ndef getAssetOpportunities(_asset: address) -> DynArray[address, MAX_VAULTS]:\n    numOpportunities: uint256 = self.numAssetOpportunities[_asset]\n    if numOpportunities == 0:\n        return []\n    opportunities: DynArray[address, MAX_VAULTS] = []\n    for i: uint256 in range(1, numOpportunities, bound=MAX_VAULTS):\n        opportunities.append(self.assetOpportunities[_asset][i])\n    return opportunities\n\n\n# all assets registered\n\n\n@view\n@external\ndef getAssets() -> DynArray[address, MAX_ASSETS]:\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return []\n    assets: DynArray[address, MAX_ASSETS] = []\n    for i: uint256 in range(1, numAssets, bound=MAX_ASSETS):\n        assets.append(self.assets[i])\n    return assets\n\n\n################\n# Registration #\n################\n\n\n@view\n@external\ndef isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    return self._isAssetOpportunity(_asset, _vaultAddr)\n\n\n@view\n@internal\ndef _isAssetOpportunity(_asset: address, _vaultAddr: address) -> bool:\n    return self.indexOfAssetOpportunity[_asset][_vaultAddr] != 0\n\n\n# add asset opportunity\n\n\n@internal\ndef _addAssetOpportunity(_asset: address, _vaultAddr: address) -> ls.VaultTokenInfo:\n    if self.indexOfAssetOpportunity[_asset][_vaultAddr] != 0:\n        return self.vaultToAsset[_vaultAddr]\n\n    if empty(address) in [_asset, _vaultAddr]:\n        return empty(ls.VaultTokenInfo)\n\n    # add asset opportunity\n    aid: uint256 = self.numAssetOpportunities[_asset]\n    if aid == 0:\n        aid = 1 # not using 0 index\n    self.assetOpportunities[_asset][aid] = _vaultAddr\n    self.indexOfAssetOpportunity[_asset][_vaultAddr] = aid\n    self.numAssetOpportunities[_asset] = aid + 1\n\n    # add mapping\n    vaultInfo: ls.VaultTokenInfo = ls.VaultTokenInfo(\n        underlyingAsset = _asset,\n        decimals = convert(staticcall IERC20Detailed(_vaultAddr).decimals(), uint256),\n        lastAveragePricePerShare = 0,\n    )\n    self.vaultToAsset[_vaultAddr] = vaultInfo\n\n    # add asset\n    self._addAsset(_asset)\n\n    log AssetOpportunityAdded(asset=_asset, vaultAddr=_vaultAddr)\n    return vaultInfo\n\n\n# remove asset opportunity\n\n\n@internal\ndef _removeAssetOpportunity(_asset: address, _vaultAddr: address):\n    numOpportunities: uint256 = self.numAssetOpportunities[_asset]\n    if numOpportunities == 0:\n        return\n\n    targetIndex: uint256 = self.indexOfAssetOpportunity[_asset][_vaultAddr]\n    if targetIndex == 0:\n        return\n\n    # update data\n    lastIndex: uint256 = numOpportunities - 1\n    self.numAssetOpportunities[_asset] = lastIndex\n    self.indexOfAssetOpportunity[_asset][_vaultAddr] = 0\n\n    self.vaultToAsset[_vaultAddr] = empty(ls.VaultTokenInfo)\n\n    # clear all snapshot data for the vault token to prevent contamination on re-add\n    self.snapShotData[_vaultAddr] = empty(ls.SnapShotData)\n\n    # clear all historical snapshots\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    for i: uint256 in range(config.maxNumSnapshots, bound=max_value(uint256)):\n        if i >= config.maxNumSnapshots:\n            break\n        self.snapShots[_vaultAddr][i] = empty(ls.SingleSnapShot)\n\n    # shift to replace the removed one\n    if targetIndex != lastIndex:\n        lastVaultAddr: address = self.assetOpportunities[_asset][lastIndex]\n        self.assetOpportunities[_asset][targetIndex] = lastVaultAddr\n        self.indexOfAssetOpportunity[_asset][lastVaultAddr] = targetIndex\n\n    # remove asset\n    if lastIndex <= 1:\n        self._removeAsset(_asset)\n\n    log AssetOpportunityRemoved(asset=_asset, vaultAddr=_vaultAddr)\n\n\n# add asset\n\n\n@internal\ndef _addAsset(_asset: address):\n    if self.indexOfAsset[_asset] != 0:\n        return\n\n    aid: uint256 = self.numAssets\n    if aid == 0:\n        aid = 1 # not using 0 index\n    self.assets[aid] = _asset\n    self.indexOfAsset[_asset] = aid\n    self.numAssets = aid + 1\n\n\n# remove asset\n\n\n@internal\ndef _removeAsset(_asset: address):\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return\n\n    targetIndex: uint256 = self.indexOfAsset[_asset]\n    if targetIndex == 0:\n        return\n\n    # update data\n    lastIndex: uint256 = numAssets - 1\n    self.numAssets = lastIndex\n    self.indexOfAsset[_asset] = 0\n\n    # shift to replace the removed one\n    if targetIndex != lastIndex:\n        lastAsset: address = self.assets[lastIndex]\n        self.assets[targetIndex] = lastAsset\n        self.indexOfAsset[lastAsset] = targetIndex\n\n\n# num lego assets (true number, use `numAssets` for iteration)\n\n\n@view\n@external\ndef getNumLegoAssets() -> uint256:\n    return self._getNumLegoAssets()\n\n\n@view\n@internal\ndef _getNumLegoAssets() -> uint256:\n    numAssets: uint256 = self.numAssets\n    if numAssets == 0:\n        return 0\n    return numAssets - 1\n\n\n###########\n# General #\n###########\n\n\n# fill mini addys\n\n\n@view\n@internal\ndef _getMiniAddys(_miniAddys: ws.MiniAddys = empty(ws.MiniAddys)) -> ws.MiniAddys:\n    if _miniAddys.ledger != empty(address):\n        return _miniAddys\n    return ws.MiniAddys(\n        ledger = addys._getLedgerAddr(),\n        missionControl = addys._getMissionControlAddr(),\n        legoBook = addys._getLegoBookAddr(),\n        appraiser = addys._getAppraiserAddr(),\n    )\n\n\n# activate\n\n\n@external\ndef pause(_shouldPause: bool):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    assert _shouldPause != self.isPaused # dev: no change\n    self.isPaused = _shouldPause\n    log LegoPauseModified(isPaused=_shouldPause)\n\n\n# recover funds\n\n\n@external\ndef recoverFunds(_recipient: address, _asset: address):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    self._recoverFunds(_recipient, _asset)\n\n\n@external\ndef recoverFundsMany(_recipient: address, _assets: DynArray[address, MAX_RECOVER_ASSETS]):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    for a: address in _assets:\n        self._recoverFunds(_recipient, a)\n\n\n@internal\ndef _recoverFunds(_recipient: address, _asset: address):\n    assert empty(address) not in [_recipient, _asset] # dev: invalid recipient or asset\n    balance: uint256 = staticcall IERC20(_asset).balanceOf(self)\n    assert balance != 0 # dev: nothing to recover\n\n    assert extcall IERC20(_asset).transfer(_recipient, balance, default_return_value=True) # dev: recovery failed\n    log LegoFundsRecovered(asset=_asset, recipient=_recipient, balance=balance)\n\n\n###################\n# Price Snapshots #\n###################\n\n\n# add price snapshot\n\n\n@internal\ndef _addPriceSnapshot(_vaultToken: address, _pricePerShare: uint256, _vaultTokenDecimals: uint256) -> bool:\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    if config.maxNumSnapshots == 0:\n        return False\n\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n\n    # already have snapshot for this time\n    if data.lastSnapShot.lastUpdate == block.timestamp:\n        return False\n\n    # check if snapshot is too recent\n    if data.lastSnapShot.lastUpdate + config.minSnapshotDelay > block.timestamp:\n        return False\n\n    # create and store new snapshot\n    newSnapshot: ls.SingleSnapShot = self._getLatestSnapshot(_vaultToken, _pricePerShare, _vaultTokenDecimals, data.lastSnapShot, config)\n    data.lastSnapShot = newSnapshot\n    self.snapShots[_vaultToken][data.nextIndex] = newSnapshot\n\n    # update index\n    data.nextIndex += 1\n    if data.nextIndex >= config.maxNumSnapshots:\n        data.nextIndex = 0\n\n    # save snap shot data\n    self.snapShotData[_vaultToken] = data\n\n    # update cached weighted average price per share\n    lastAveragePricePerShare: uint256 = self._getWeightedPricePerShare(_vaultToken, _pricePerShare)\n    self.vaultToAsset[_vaultToken].lastAveragePricePerShare = lastAveragePricePerShare\n\n    log PricePerShareSnapShotAdded(\n        vaultToken = _vaultToken,\n        totalSupply = newSnapshot.totalSupply,\n        pricePerShare = newSnapshot.pricePerShare,\n        lastAveragePricePerShare = lastAveragePricePerShare,\n    )\n    return True\n\n\n# weighted price per share\n\n\n@view\n@external\ndef getWeightedPricePerShare(_vaultToken: address) -> uint256:\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n    return self._getWeightedPricePerShare(_vaultToken, data.lastSnapShot.pricePerShare)\n\n\n@view\n@internal\ndef _getWeightedPricePerShare(_vaultToken: address, _lastPricePerShare: uint256) -> uint256:\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    if config.maxNumSnapshots == 0:\n        return 0\n\n    # calculate weighted average price using all valid snapshots\n    numerator: uint256 = 0\n    denominator: uint256 = 0\n    for i: uint256 in range(config.maxNumSnapshots, bound=max_value(uint256)):\n\n        snapShot: ls.SingleSnapShot = self.snapShots[_vaultToken][i]\n        if snapShot.pricePerShare == 0 or snapShot.totalSupply == 0 or snapShot.lastUpdate == 0:\n            continue\n\n        # too stale, skip\n        if config.staleTime != 0 and block.timestamp > snapShot.lastUpdate + config.staleTime:\n            continue\n\n        numerator += (snapShot.totalSupply * snapShot.pricePerShare)\n        denominator += snapShot.totalSupply\n\n    # weighted price per share\n    weightedPricePerShare: uint256 = 0\n    if numerator != 0:\n        weightedPricePerShare = numerator // denominator\n    else:\n        weightedPricePerShare = _lastPricePerShare\n\n    return weightedPricePerShare\n\n\n# latest snapshot\n\n\n@view\n@external\ndef getLatestSnapshot(_vaultToken: address, _pricePerShare: uint256) -> ls.SingleSnapShot:\n    data: ls.SnapShotData = self.snapShotData[_vaultToken]\n    config: ls.SnapShotPriceConfig = self.snapShotPriceConfig\n    vaultTokenDecimals: uint256 = self.vaultToAsset[_vaultToken].decimals\n    return self._getLatestSnapshot(_vaultToken, _pricePerShare, vaultTokenDecimals, data.lastSnapShot, config)\n\n\n@view\n@internal\ndef _getLatestSnapshot(\n    _vaultToken: address,\n    _pricePerShare: uint256,\n    _vaultTokenDecimals: uint256,\n    _lastSnapShot: ls.SingleSnapShot,\n    _config: ls.SnapShotPriceConfig,\n) -> ls.SingleSnapShot:\n\n    # total supply (adjusted)\n    totalSupply: uint256 = staticcall IERC20(_vaultToken).totalSupply() // (10 ** _vaultTokenDecimals)\n    if totalSupply == 0:\n        totalSupply = 1\n\n    # throttle upside (extra safety check)\n    pricePerShare: uint256 = self._throttleUpside(_pricePerShare, _lastSnapShot.pricePerShare, _config.maxUpsideDeviation)\n\n    return ls.SingleSnapShot(\n        totalSupply = totalSupply,\n        pricePerShare = pricePerShare,\n        lastUpdate = block.timestamp,\n    )\n\n\n@pure\n@internal\ndef _throttleUpside(_newValue: uint256, _prevValue: uint256, _maxUpside: uint256) -> uint256:\n    if _maxUpside == 0 or _prevValue == 0 or _newValue == 0:\n        return _newValue\n    maxPricePerShare: uint256 = _prevValue + (_prevValue * _maxUpside // HUNDRED_PERCENT)\n    return min(_newValue, maxPricePerShare)\n\n\n# snapshot price config\n\n\n@external\ndef setSnapShotPriceConfig(_config: ls.SnapShotPriceConfig):\n    assert addys._isSwitchboardAddr(msg.sender) # dev: no perms\n    assert self._isValidPriceConfig(_config) # dev: invalid config\n    self.snapShotPriceConfig = _config\n    log SnapShotPriceConfigSet(\n        minSnapshotDelay=_config.minSnapshotDelay,\n        maxNumSnapshots=_config.maxNumSnapshots,\n        maxUpsideDeviation=_config.maxUpsideDeviation,\n        staleTime=_config.staleTime\n    )\n\n\n@pure\n@external\ndef isValidPriceConfig(_config: ls.SnapShotPriceConfig) -> bool:\n    return self._isValidPriceConfig(_config)\n\n\n@pure\n@internal\ndef _isValidPriceConfig(_config: ls.SnapShotPriceConfig) -> bool:\n    if _config.minSnapshotDelay > ONE_WEEK_SECONDS:\n        return False\n    if _config.maxNumSnapshots == 0 or _config.maxNumSnapshots > 25:\n        return False\n    if _config.maxUpsideDeviation > HUNDRED_PERCENT:\n        return False\n    return _config.staleTime < ONE_WEEK_SECONDS",
+            "sha256sum": "a6a22b1f8df8bc05dc2a6d10bdd7abd22abc149272255b3ac43765ca5d9a25b0"
+          },
+          "contracts/legos/yield/RecoveryLego.vy": {
+            "content": "#     Underscore Protocol License: https://github.com/underscore-finance/underscore-protocol/blob/master/LICENSE.md\n\n# @version 0.4.3\n\nimplements: Lego\nimplements: YieldLego\n\nexports: addys.__interface__\nexports: yld.__interface__\n\ninitializes: addys\ninitializes: yld[addys := addys]\n\nfrom interfaces import LegoPartner as Lego\nfrom interfaces import YieldLego as YieldLego\nfrom interfaces import WalletStructs as ws\n\nimport contracts.modules.Addys as addys\nimport contracts.modules.YieldLegoData as yld\n\nfrom ethereum.ercs import IERC20\n\ninterface UndyHq:\n    def governance() -> address: view\n\ninterface Ledger:\n    def isUserWallet(_user: address) -> bool: view\n\ninterface UserWallet:\n    def walletConfig() -> address: view\n\ninterface UserWalletConfig:\n    def indexOfManager(_addr: address) -> uint256: view\n\nstruct Recovery:\n    user: address\n    asset: address\n    recipient: address\n\nevent RecoveryDeposit:\n    user: indexed(address)\n    asset: indexed(address)\n    amount: uint256\n\nevent FundsMigrated:\n    user: indexed(address)\n    asset: indexed(address)\n    recipient: indexed(address)\n    amount: uint256\n\nMAX_TOKEN_PATH: constant(uint256) = 5\nMAX_PROOFS: constant(uint256) = 25\nMAX_RECOVERIES: constant(uint256) = 30\n\nAGENT_WRAPPER: constant(address) = 0x8ee401f1E0F4CC0Ed57318AB6dAab1F1Fb59f65f\n\n# user -> asset -> amount\nuserAssets: public(HashMap[address, HashMap[address, uint256]])\n\n\n@deploy\ndef __init__(_undyHq: address):\n    assert empty(address) not in [_undyHq] # dev: invalid addrs\n    addys.__init__(_undyHq)\n    yld.__init__(False)\n\n\n@view\n@internal\ndef _canMigrate(_caller: address) -> bool:\n    return _caller == staticcall UndyHq(addys._getUndyHq()).governance()\n\n\n@view\n@internal\ndef _isUserWallet(_wallet: address) -> bool:\n    ledger: address = addys._getLedgerAddr()\n    if ledger == empty(address):\n        return False\n    return staticcall Ledger(ledger).isUserWallet(_wallet)\n\n\n#########\n# Views #\n#########\n\n\n@view\n@external\ndef hasCapability(_action: ws.ActionType) -> bool:\n    return _action == ws.ActionType.EARN_DEPOSIT\n\n\n@view\n@external\ndef getRegistries() -> DynArray[address, 10]:\n    return []\n\n\n@view\n@external\ndef isYieldLego() -> bool:\n    return True\n\n\n@view\n@external\ndef isDexLego() -> bool:\n    return False\n\n\n###################\n# Underlying Data #\n###################\n\n\n@view\n@external\ndef getUnderlyingAsset(_vaultToken: address) -> address:\n    return empty(address)\n\n\n@view\n@external\ndef getUnderlyingBalances(_vaultToken: address, _vaultTokenBalance: uint256) -> (uint256, uint256):\n    return 0, 0\n\n\n@view\n@external\ndef getUnderlyingAmount(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUnderlyingAmountSafe(_vaultToken: address, _vaultTokenBalance: uint256) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUnderlyingData(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> (address, uint256, uint256):\n    return empty(address), 0, 0\n\n\n@view\n@external\ndef getUsdValueOfVaultToken(_vaultToken: address, _vaultTokenAmount: uint256, _appraiser: address = empty(address)) -> uint256:\n    return 0\n\n\n###############\n# Other Utils #\n###############\n\n\n@view\n@external\ndef isRebasing() -> bool:\n    return False\n\n\n@view\n@external\ndef getPricePerShare(_vaultToken: address, _decimals: uint256 = 0) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef canRegisterVaultToken(_asset: address, _vaultToken: address) -> bool:\n    return False\n\n\n@view\n@external\ndef totalAssets(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef totalBorrows(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getUtilizationRatio(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef getAvailLiquidity(_vaultToken: address) -> uint256:\n    return 0\n\n\n@view\n@external\ndef isEligibleForYieldBonus(_asset: address) -> bool:\n    return False\n\n\n@view\n@external\ndef getWithdrawalFees(_vaultToken: address, _vaultTokenAmount: uint256) -> uint256:\n    return 0\n\n\n#################\n# Yield Actions #\n#################\n\n\n@external\ndef depositForYield(\n    _asset: address,\n    _amount: uint256,\n    _vaultAddr: address,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, address, uint256, uint256):\n    assert not yld.isPaused # dev: paused\n    assert self._isUserWallet(msg.sender) # dev: not a user wallet\n    assert _asset != empty(address) # dev: invalid asset\n\n    depositAmount: uint256 = min(_amount, staticcall IERC20(_asset).balanceOf(msg.sender))\n    assert depositAmount != 0 # dev: nothing to transfer\n    assert extcall IERC20(_asset).transferFrom(msg.sender, self, depositAmount, default_return_value=True) # dev: transfer failed\n\n    self.userAssets[msg.sender][_asset] += depositAmount\n\n    log RecoveryDeposit(user=msg.sender, asset=_asset, amount=depositAmount)\n    return depositAmount, empty(address), 0, 1\n\n\n@external\ndef withdrawFromYield(\n    _vaultToken: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, address, uint256, uint256):\n    return 0, empty(address), 0, 0\n\n\n@external\ndef migrateFunds(_recoveries: DynArray[Recovery, MAX_RECOVERIES]) -> bool:\n    assert self._canMigrate(msg.sender) # dev: no perms\n\n    for r: Recovery in _recoveries:\n        if empty(address) in [r.asset, r.recipient]:\n            continue\n\n        assert self._isUserWallet(r.recipient) # dev: not a user wallet\n        config: address = staticcall UserWallet(r.recipient).walletConfig()\n        assert staticcall UserWalletConfig(config).indexOfManager(AGENT_WRAPPER) != 0 # dev: recipient wallet not managed by UndyHq\n\n        recordedAmount: uint256 = self.userAssets[r.user][r.asset]\n        if recordedAmount == 0:\n            continue\n\n        amount: uint256 = min(recordedAmount, staticcall IERC20(r.asset).balanceOf(self))\n        if amount == 0:\n            continue\n\n        self.userAssets[r.user][r.asset] = recordedAmount - amount\n        assert extcall IERC20(r.asset).transfer(r.recipient, amount, default_return_value=True) # dev: transfer failed\n        log FundsMigrated(user=r.user, asset=r.asset, recipient=r.recipient, amount=amount)\n\n    return True\n\n\n@external\ndef addPriceSnapshot(_vaultToken: address) -> bool:\n    return False\n\n\n#########\n# Other #\n#########\n\n\n@view\n@external\ndef getAccessForLego(_user: address, _action: ws.ActionType) -> (address, String[64], uint256):\n    return empty(address), empty(String[64]), 0\n\n\n@external\ndef claimIncentives(\n    _user: address,\n    _rewardToken: address,\n    _rewardAmount: uint256,\n    _proofs: DynArray[bytes32, MAX_PROOFS],\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@pure\n@external\ndef claimRewards(\n    _user: address,\n    _rewardToken: address,\n    _rewardAmount: uint256,\n    _extraData: bytes32,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef swapTokens(\n    _amountIn: uint256,\n    _minAmountOut: uint256,\n    _tokenPath: DynArray[address, MAX_TOKEN_PATH],\n    _poolPath: DynArray[address, MAX_TOKEN_PATH - 1],\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256):\n    return 0, 0, 0\n\n\n@external\ndef mintOrRedeemAsset(\n    _tokenIn: address,\n    _tokenOut: address,\n    _tokenInAmount: uint256,\n    _minAmountOut: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, bool, uint256):\n    return 0, 0, False, 0\n\n\n@external\ndef confirmMintOrRedeemAsset(\n    _tokenIn: address,\n    _tokenOut: address,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef borrow(\n    _borrowAsset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef repayDebt(\n    _paymentAsset: address,\n    _paymentAmount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef removeCollateral(\n    _asset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef addCollateral(\n    _asset: address,\n    _amount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256):\n    return 0, 0\n\n\n@external\ndef addLiquidity(\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _amountA: uint256,\n    _amountB: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _minLpAmount: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (address, uint256, uint256, uint256, uint256):\n    return empty(address), 0, 0, 0, 0\n\n\n@external\ndef removeLiquidity(\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _lpToken: address,\n    _lpAmount: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, uint256):\n    return 0, 0, 0, 0\n\n\n@external\ndef addLiquidityConcentrated(\n    _nftTokenId: uint256,\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _tickLower: int24,\n    _tickUpper: int24,\n    _amountA: uint256,\n    _amountB: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, uint256, uint256):\n    return 0, 0, 0, 0, 0\n\n\n@external\ndef removeLiquidityConcentrated(\n    _nftTokenId: uint256,\n    _pool: address,\n    _tokenA: address,\n    _tokenB: address,\n    _liqToRemove: uint256,\n    _minAmountA: uint256,\n    _minAmountB: uint256,\n    _extraData: bytes32,\n    _recipient: address,\n    _miniAddys: ws.MiniAddys = empty(ws.MiniAddys),\n) -> (uint256, uint256, uint256, bool, uint256):\n    return 0, 0, 0, False, 0\n",
+            "sha256sum": "5d508327db7efde65e695775db435580d843988b55513b99447d87d24caf0745"
+          }
+        },
+        "settings": {
+          "outputSelection": {
+            "contracts/legos/yield/RecoveryLego.vy": [
+              "*"
+            ]
+          },
+          "search_paths": [
+            "."
+          ]
+        },
+        "compiler_version": "v0.4.3+commit.bff19ea2",
+        "integrity": "c1c1c091c594b8fdf932a7f808ed83709b480c8a9d42010802f25361596ed126"
+      },
+      "args": "00000000000000000000000044cf3c4f000dfd76a35d03298049d37be688d6f9",
+      "file": "contracts/legos/yield/RecoveryLego.vy"
     }
   }
 }

--- a/migrations/base-mainnet/v1.1/2026060900-RecoveryLego.py
+++ b/migrations/base-mainnet/v1.1/2026060900-RecoveryLego.py
@@ -1,0 +1,9 @@
+from scripts.utils.migration import Migration
+
+
+def migrate(migration: Migration):
+
+    hq = migration.get_address("UndyHq")
+    recovery_lego = migration.deploy("RecoveryLego", hq)
+
+    print(f"Deployed RecoveryLego at {recovery_lego.address}")

--- a/tests/legos/yield/test_recovery_lego.py
+++ b/tests/legos/yield/test_recovery_lego.py
@@ -1,0 +1,78 @@
+import boa
+import pytest
+
+from constants import EIGHTEEN_DECIMALS, ZERO_ADDRESS
+
+
+@pytest.fixture
+def recovery_lego(undy_hq_deploy, governance, lego_book):
+    lego = boa.load(
+        "contracts/legos/yield/RecoveryLego.vy",
+        undy_hq_deploy,
+        governance,
+        name="recovery_lego",
+    )
+    lego_book.startAddNewAddressToRegistry(lego, "Recovery Lego", sender=governance.address)
+    boa.env.time_travel(blocks=lego_book.registryChangeTimeLock() + 1)
+    lego_id = lego_book.confirmNewAddressToRegistry(lego, sender=governance.address)
+    return lego, lego_id
+
+
+def test_recovery_lego_deposit_and_migrate(
+    recovery_lego,
+    bob_user_wallet,
+    bob,
+    governance,
+    yield_underlying_token,
+    yield_underlying_token_whale,
+    sally,
+):
+    lego, lego_id = recovery_lego
+    amount = 1_000 * EIGHTEEN_DECIMALS
+
+    yield_underlying_token.transfer(bob_user_wallet, amount, sender=yield_underlying_token_whale)
+
+    deposit_amount, vault_token, vault_token_amount, usd_value = bob_user_wallet.depositForYield(
+        lego_id,
+        yield_underlying_token,
+        ZERO_ADDRESS,
+        amount,
+        sender=bob,
+    )
+
+    assert deposit_amount == amount
+    assert vault_token == ZERO_ADDRESS
+    assert vault_token_amount == 0
+    assert usd_value == 0
+    assert yield_underlying_token.balanceOf(lego) == amount
+    assert lego.userAssets(bob_user_wallet, yield_underlying_token) == amount
+
+    with boa.reverts("no perms"):
+        lego.migrateFunds([(bob_user_wallet.address, yield_underlying_token.address, sally)], sender=bob)
+
+    assert lego.migrateFunds([(bob_user_wallet.address, yield_underlying_token.address, sally)], sender=governance.address)
+    assert yield_underlying_token.balanceOf(sally) == amount
+    assert yield_underlying_token.balanceOf(lego) == 0
+    assert lego.userAssets(bob_user_wallet, yield_underlying_token) == 0
+
+
+def test_recovery_lego_rejects_non_wallet_deposit(
+    recovery_lego,
+    bob,
+    yield_underlying_token,
+    yield_underlying_token_whale,
+):
+    lego, _ = recovery_lego
+    amount = 100 * EIGHTEEN_DECIMALS
+
+    yield_underlying_token.transfer(bob, amount, sender=yield_underlying_token_whale)
+
+    with boa.reverts("not a user wallet"):
+        lego.depositForYield(
+            yield_underlying_token,
+            amount,
+            ZERO_ADDRESS,
+            b"",
+            bob,
+            sender=bob,
+        )


### PR DESCRIPTION
## Summary
- Add `RecoveryLego` implementing the current `LegoPartner` and `YieldLego` interfaces.
- Record deposited user assets from registered user wallets and allow governance to migrate recorded balances to recipients.
- Add focused tests for wallet deposit, governance migration, unauthorized migration, and non-wallet deposit rejection.

## Tests
- `.venv/bin/python - <<'PY'
import boa
boa.load_partial('contracts/legos/yield/RecoveryLego.vy')
print('compiled')
PY`
- `PYTHONPATH=. ETHERSCAN_API_KEY=dummy .venv/bin/pytest tests/legos/yield/test_recovery_lego.py -q`