### PR TITLE
Prevent invalid LegoBook entries from reverting all LegoTools swaps

### DIFF
--- a/contracts/legos/LegoTools.vy
+++ b/contracts/legos/LegoTools.vy
@@ -162,6 +162,25 @@ def __init__(
     CURVE_ID = _curveId
 
 
+# NOTE: a LegoBook entry can be disabled -- its address is wiped to
+# empty(address) while its regId still counts toward numAddrs. Every loop below
+# walks range(1, numAddrs), so it must skip those holes: calling isDexLego() /
+# isYieldLego() on empty(address) reverts, which would brick swap routing (and
+# yield lookups) for everyone the moment a single lego is disabled.
+@view
+@internal
+def _getLiveLegoAddr(_legoBook: address, _index: uint256, _isDex: bool) -> address:
+    legoAddr: address = staticcall Registry(_legoBook).getAddr(_index)
+    if legoAddr == empty(address):
+        return empty(address) # disabled / invalid registry entry
+    if _isDex:
+        if staticcall LegoPartner(legoAddr).isDexLego():
+            return legoAddr
+    elif staticcall LegoPartner(legoAddr).isYieldLego():
+        return legoAddr
+    return empty(address) # wrong lego kind for this loop
+
+
 ###############
 # Yield Legos #
 ###############
@@ -327,8 +346,8 @@ def getUnderlyingAsset(_vaultToken: address, _legoBook: address = empty(address)
         return empty(address)
 
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
-        legoAddr: address = staticcall Registry(legoBook).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isYieldLego():
+        legoAddr: address = self._getLiveLegoAddr(legoBook, i, False)
+        if legoAddr == empty(address): # skip disabled / invalid / non-yield legos
             continue
 
         asset: address = staticcall YieldLego(legoAddr).getUnderlyingAsset(_vaultToken)
@@ -357,8 +376,8 @@ def getUnderlyingForUser(_user: address, _asset: address, _legoBook: address = e
 
     totalDeposited: uint256 = 0
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
-        legoAddr: address = staticcall Registry(legoBook).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isYieldLego():
+        legoAddr: address = self._getLiveLegoAddr(legoBook, i, False)
+        if legoAddr == empty(address): # skip disabled / invalid / non-yield legos
             continue
 
         legoVaultTokens: DynArray[address, MAX_VAULTS] = staticcall YieldLego(legoAddr).getAssetOpportunities(_asset)
@@ -394,8 +413,8 @@ def getVaultTokensForUser(_user: address, _asset: address, _legoBook: address = 
 
     vaultTokens: DynArray[VaultTokenInfo, MAX_VAULTS_FOR_USER] = []
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
-        legoAddr: address = staticcall Registry(legoBook).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isYieldLego():
+        legoAddr: address = self._getLiveLegoAddr(legoBook, i, False)
+        if legoAddr == empty(address): # skip disabled / invalid / non-yield legos
             continue
 
         legoVaultTokens: DynArray[address, MAX_VAULTS] = staticcall YieldLego(legoAddr).getAssetOpportunities(_asset)
@@ -432,8 +451,8 @@ def isVaultToken(_vaultToken: address, _legoBook: address = empty(address)) -> b
         return False
 
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
-        legoAddr: address = staticcall Registry(legoBook).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isYieldLego():
+        legoAddr: address = self._getLiveLegoAddr(legoBook, i, False)
+        if legoAddr == empty(address): # skip disabled / invalid / non-yield legos
             continue
 
         if staticcall YieldLego(legoAddr).isLegoAsset(_vaultToken):
@@ -460,8 +479,8 @@ def getVaultTokenAmount(_asset: address, _assetAmount: uint256, _vaultToken: add
         return 0
 
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
-        legoAddr: address = staticcall Registry(legoBook).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isYieldLego():
+        legoAddr: address = self._getLiveLegoAddr(legoBook, i, False)
+        if legoAddr == empty(address): # skip disabled / invalid / non-yield legos
             continue
 
         vaultTokenAmount: uint256 = staticcall YieldLego(legoAddr).getVaultTokenAmount(_asset, _assetAmount, _vaultToken)
@@ -490,6 +509,8 @@ def getLegoInfoFromVaultToken(_vaultToken: address, _legoBook: address = empty(a
 
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
         legoInfo: AddressInfo = staticcall Registry(legoBook).getAddrInfo(i)
+        if legoInfo.addr == empty(address): # skip disabled / invalid legos
+            continue
         if not staticcall LegoPartner(legoInfo.addr).isYieldLego():
             continue
 
@@ -519,6 +540,8 @@ def getUnderlyingData(_asset: address, _amount: uint256, _legoBook: address = em
     appraiser: address = addys._getAppraiserAddr()
     for i: uint256 in range(1, numLegos, bound=max_value(uint256)):
         legoInfo: AddressInfo = staticcall Registry(legoBook).getAddrInfo(i)
+        if legoInfo.addr == empty(address): # skip disabled / invalid legos
+            continue
         if not staticcall LegoPartner(legoInfo.addr).isYieldLego():
             continue
 
@@ -870,8 +893,8 @@ def _getBestSwapAmountOutSinglePool(
             continue
 
         # get lego addr
-        legoAddr: address = staticcall Registry(_legoRegistry).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isDexLego():
+        legoAddr: address = self._getLiveLegoAddr(_legoRegistry, i, True)
+        if legoAddr == empty(address): # skip disabled / invalid / non-dex legos
             continue
 
         pool: address = empty(address)
@@ -937,8 +960,8 @@ def _getSwapAmountOutViaRouterPool(
             continue
 
         # get lego addr
-        legoAddr: address = staticcall Registry(_legoRegistry).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isDexLego():
+        legoAddr: address = self._getLiveLegoAddr(_legoRegistry, i, True)
+        if legoAddr == empty(address): # skip disabled / invalid / non-dex legos
             continue
 
         pool: address = staticcall DexLego(legoAddr).getCoreRouterPool()
@@ -1187,8 +1210,8 @@ def _getBestSwapAmountInSinglePool(
             continue
 
         # get lego addr
-        legoAddr: address = staticcall Registry(_legoRegistry).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isDexLego():
+        legoAddr: address = self._getLiveLegoAddr(_legoRegistry, i, True)
+        if legoAddr == empty(address): # skip disabled / invalid / non-dex legos
             continue
 
         pool: address = empty(address)
@@ -1254,8 +1277,8 @@ def _getSwapAmountInViaRouterPool(
             continue
 
         # get lego addr
-        legoAddr: address = staticcall Registry(_legoRegistry).getAddr(i)
-        if not staticcall LegoPartner(legoAddr).isDexLego():
+        legoAddr: address = self._getLiveLegoAddr(_legoRegistry, i, True)
+        if legoAddr == empty(address): # skip disabled / invalid / non-dex legos
             continue
 
         # get router pool

--- a/tests/helpers/test_lego_tools_disabled_legos.py
+++ b/tests/helpers/test_lego_tools_disabled_legos.py
@@ -1,0 +1,152 @@
+import boa
+import pytest
+
+from constants import ZERO_ADDRESS
+
+
+# HIG-383 regression tests.
+#
+# A LegoBook entry can be *disabled*: AddressRegistry sets addrInfo[regId].addr
+# to empty(address) but keeps that regId within numAddrs, and isValidRegId()
+# stays true for it. LegoTools walks `range(1, numAddrs)` and used to call
+# isDexLego()/isYieldLego() on getAddr(i) directly -- a staticcall against 0x0
+# reverts, so a single disabled lego reverted *every* swap-route quote (and
+# every yield lookup) for every user. LegoTools now skips empty entries; these
+# tests pin that behaviour.
+#
+# The shared `lego_tools` fixture skips on the local fork (it wires up real DEX
+# legos), so we build LegoTools directly against the local `lego_book`
+# (regId 1 = ripe, 2 = mock yield, 3 = mock dex). Swap routing always resolves
+# the LegoBook from undy_hq, so mutations to it happen inside boa.env.anchor()
+# to keep the session-scoped fixture pristine for other tests.
+
+
+MAX_UINT256 = 2**256 - 1
+ROUTE_AMOUNT = 1_000 * 10**18
+
+
+@pytest.fixture
+def lego_tools_local(undy_hq_deploy, lego_book, mock_dex_lego, mock_yield_lego, alpha_token, weth):
+    dex_id = lego_book.getRegId(mock_dex_lego)
+    yield_id = lego_book.getRegId(mock_yield_lego)
+    return boa.load(
+        "contracts/legos/LegoTools.vy",
+        undy_hq_deploy,
+        alpha_token,  # ROUTER_TOKENA (usdc on local)
+        weth,         # ROUTER_TOKENB
+        # yield lego ids -- only need to be valid regIds; routing walks the
+        # whole book regardless of which id sits in which slot
+        yield_id, yield_id, yield_id, yield_id, yield_id, yield_id,
+        # dex lego ids -- keep the "non-standard" uniV3 / aero-slipstream ids
+        # off the mock dex so it is quoted through the standard staticcall path
+        dex_id, yield_id, dex_id, yield_id, dex_id,
+        name="lego_tools_local",
+    )
+
+
+def _route_key(route):
+    return (route.legoId, route.pool, route.tokenIn, route.tokenOut, route.amountIn, route.amountOut)
+
+
+def _disable_in_registry(registry, reg_id, sender):
+    registry.startAddressDisableInRegistry(reg_id, sender=sender)
+    boa.env.time_travel(blocks=registry.registryChangeTimeLock() + 1)
+    assert registry.confirmAddressDisableInRegistry(reg_id, sender=sender)
+    # the exact state that used to brick LegoTools: address wiped to zero, but
+    # the regId still counts toward numAddrs so the loop keeps visiting it
+    assert registry.getAddr(reg_id) == ZERO_ADDRESS
+    assert registry.isValidRegId(reg_id)
+
+
+def test_swap_quotes_unaffected_by_disabled_non_dex_lego(
+    lego_tools_local, lego_book, mock_yield_lego, governance, alpha_token, weth
+):
+    """Disabling a non-dex lego must be a transparent no-op for swap routing."""
+    baseline = [
+        lego_tools_local.getBestSwapAmountOutSinglePool(weth, alpha_token, ROUTE_AMOUNT),
+        lego_tools_local.getSwapAmountOutViaRouterPool(weth, alpha_token, ROUTE_AMOUNT),
+        lego_tools_local.getBestSwapAmountInSinglePool(weth, alpha_token, ROUTE_AMOUNT),
+        lego_tools_local.getSwapAmountInViaRouterPool(weth, alpha_token, ROUTE_AMOUNT),
+    ]
+
+    with boa.env.anchor():
+        # pre-fix this reverted on the isDexLego() staticcall against 0x0
+        _disable_in_registry(lego_book, lego_book.getRegId(mock_yield_lego), governance.address)
+
+        after = [
+            lego_tools_local.getBestSwapAmountOutSinglePool(weth, alpha_token, ROUTE_AMOUNT),
+            lego_tools_local.getSwapAmountOutViaRouterPool(weth, alpha_token, ROUTE_AMOUNT),
+            lego_tools_local.getBestSwapAmountInSinglePool(weth, alpha_token, ROUTE_AMOUNT),
+            lego_tools_local.getSwapAmountInViaRouterPool(weth, alpha_token, ROUTE_AMOUNT),
+        ]
+        assert lego_tools_local.getBestSwapRoutesAmountOut(weth, alpha_token, ROUTE_AMOUNT) == []
+        assert lego_tools_local.getBestSwapRoutesAmountIn(weth, alpha_token, ROUTE_AMOUNT) == []
+
+    assert [_route_key(r) for r in after] == [_route_key(r) for r in baseline]
+
+
+def test_swap_quotes_survive_disabled_dex_lego(
+    lego_tools_local, lego_book, mock_dex_lego, governance, alpha_token, weth
+):
+    """Disabling the dex lego itself must be skipped, not reverted on."""
+    with boa.env.anchor():
+        _disable_in_registry(lego_book, lego_book.getRegId(mock_dex_lego), governance.address)
+
+        # none of these may revert now that the only dex lego is disabled
+        out_single = lego_tools_local.getBestSwapAmountOutSinglePool(weth, alpha_token, ROUTE_AMOUNT)
+        out_router = lego_tools_local.getSwapAmountOutViaRouterPool(weth, alpha_token, ROUTE_AMOUNT)
+        in_single = lego_tools_local.getBestSwapAmountInSinglePool(weth, alpha_token, ROUTE_AMOUNT)
+        in_router = lego_tools_local.getSwapAmountInViaRouterPool(weth, alpha_token, ROUTE_AMOUNT)
+        routes_out = lego_tools_local.getBestSwapRoutesAmountOut(weth, alpha_token, ROUTE_AMOUNT)
+        routes_in = lego_tools_local.getBestSwapRoutesAmountIn(weth, alpha_token, ROUTE_AMOUNT)
+
+    # no dex lego left -> no route found, but the loop completed cleanly
+    for route in (out_single, out_router):
+        assert route.legoId == 0
+        assert route.pool == ZERO_ADDRESS
+        assert route.amountOut == 0
+    for route in (in_single, in_router):
+        assert route.legoId == 0
+        assert route.pool == ZERO_ADDRESS
+        assert route.amountIn == MAX_UINT256
+    assert routes_out == []
+    assert routes_in == []
+
+
+def test_yield_lookups_survive_disabled_lego(
+    undy_hq_deploy, lego_book, lego_tools_local, mock_yield_lego, governance, weth
+):
+    """Pattern-A yield loops must skip a disabled lego instead of reverting.
+
+    Built against a fresh, fully-controlled LegoBook passed via the `_legoBook`
+    arg (unlike swap routing, the yield lookups accept an explicit book), so the
+    result does not depend on which legos other tests registered this session.
+    """
+    # a second, independent yield lego so a *yield* lego can be disabled while
+    # another enabled yield lego remains for the loop to reach past it
+    mock_yield_2 = boa.load("contracts/mock/MockYieldLego.vy", undy_hq_deploy, name="mock_yield_2")
+
+    fresh_book = boa.load(
+        "contracts/registries/LegoBook.vy",
+        undy_hq_deploy,
+        ZERO_ADDRESS,  # gov defers to undy_hq -> its governor after setup is `governance`
+        lego_book.minRegistryTimeLock(),
+        lego_book.maxRegistryTimeLock(),
+        name="fresh_lego_book",
+    )
+    gov = governance.address
+    # registry is in setup mode (timelock 0) -> confirms are instant
+    assert fresh_book.startAddNewAddressToRegistry(mock_yield_lego, "yield 1", sender=gov)
+    assert fresh_book.confirmNewAddressToRegistry(mock_yield_lego, sender=gov) == 1
+    assert fresh_book.startAddNewAddressToRegistry(mock_yield_2, "yield 2", sender=gov)
+    assert fresh_book.confirmNewAddressToRegistry(mock_yield_2, sender=gov) == 2
+
+    # disable the first yield lego (regId 1)
+    assert fresh_book.startAddressDisableInRegistry(1, sender=gov)
+    assert fresh_book.confirmAddressDisableInRegistry(1, sender=gov)
+    assert fresh_book.getAddr(1) == ZERO_ADDRESS
+    assert fresh_book.isValidRegId(1)  # still counted -> loop still visits it
+
+    # pre-fix this reverted at regId 1 (isYieldLego() staticcall against 0x0);
+    # it now walks past the disabled entry to the live yield lego at regId 2
+    assert lego_tools_local.getUnderlyingAsset(weth, fresh_book) == ZERO_ADDRESS


### PR DESCRIPTION
## HIG-383

Fixes [HIG-383](https://linear.app/hightop/issue/HIG-383/prevent-invalid-legobook-entries-from-reverting-all-legotools-swap).

### The bug
A LegoBook entry can be **disabled**: `AddressRegistry._confirmAddressDisableInRegistry` wipes `addrInfo[regId].addr` to `empty(address)` but keeps that `regId` within `numAddrs`, and `isValidRegId(regId)` stays `true`.

`LegoTools` iterates `range(1, numAddrs)` and called the lego classifier directly on the fetched address:

```vyper
legoAddr: address = staticcall Registry(_legoRegistry).getAddr(i)
if not staticcall LegoPartner(legoAddr).isDexLego():   # legoAddr == 0x0 -> reverts
    continue
```

A `staticcall` to `0x0` reverts (empty returndata fails the ABI decode), so **one disabled lego reverts every swap-route quote** — `getBestSwapRoutesAmountOut/In`, all four single-pool / router-pool quoters, and therefore the whole swap-instruction builder. The identical pattern also affected the yield/vault lookups (`getUnderlyingAsset`, `isVaultToken`, `getVaultTokensForUser`, `getVaultTokenAmount`, `getLegoInfoFromVaultToken`, `getUnderlyingData`), so appraisal reads broke the same way.

### The fix
A single shared internal helper resolves a live lego (or `empty` for a disabled / wrong-kind entry), and every loop skips the holes:

```vyper
@view
@internal
def _getLiveLegoAddr(_legoBook: address, _index: uint256, _isDex: bool) -> address:
    legoAddr: address = staticcall Registry(_legoBook).getAddr(_index)
    if legoAddr == empty(address):
        return empty(address)
    ...
```

All 11 lego loops are covered (9 via the helper, the 2 `getAddrInfo` loops guard inline since they also need the entry description).

### Contract size (important)
`LegoTools` was only **~82 bytes under the EIP-170 24,576-byte limit** (deployed = runtime bytecode + ~480 bytes of immutables). A naive inline guard at each of the 11 sites pushed it **17 bytes over** — undeployable on Base. Folding the 9 `getAddr` loops into one helper applies the fix **and shrinks runtime bytecode ~700 bytes** (24,014 → 23,312), restoring comfortable headroom. The routing logic is otherwise behavior-preserving: the helper returns exactly the lego each loop would previously have used, `empty` where it would previously have `continue`d.

### Tests
`tests/helpers/test_lego_tools_disabled_legos.py` (runs on `--fork local`, which CI uses):
- swap quotes are unaffected when a non-dex lego is disabled;
- swap quotes still resolve (no revert) when the dex lego itself is disabled;
- yield lookups skip a disabled lego and reach the next live one.

The shared `lego_tools` fixture is base-fork only (DEX legos skip on local), so the tests build `LegoTools` inline against the local `lego_book` and disable entries inside `boa.env.anchor()`. **All three fail on the pre-fix contract and pass on this branch.** Full `tests/helpers/` suite: 86 passed, 26 skipped.

> Note: base-fork swap-routing tests were not run in this environment (no Alchemy RPC key). There is no pre-existing test exercising the routing entrypoints; the local tests added here are the first to do so.