### PR TITLE
Refuse migrations against Ethereum mainnet by default

### DIFF
--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -10,7 +10,9 @@ from boa.environment import Env
 from scripts.utils.mock_account import MockAccount
 # from scripts.utils.safe_account import SafeAccount
 # from scripts.utils.ledger_account import LedgerAccount
+import json
 import os
+import urllib.request
 
 
 MIGRATION_SCRIPTS_DIR = "./migrations"
@@ -98,6 +100,81 @@ ETHERSCAN_URLS = {
     "base-goerli": "https://api-goerli.basescan.org/api",
     "base-sepolia": "https://api-sepolia.basescan.org/api",
 }
+
+
+ETH_MAINNET_CHAIN_ID = 1
+ALLOW_ETH_MAINNET_ENV = "ALLOW_ETH_MAINNET_DEPLOY"
+
+
+def resolve_chain_id(rpc_url, attempts=2):
+    """`eth_chainId` lookup. Returns None if it cannot be determined.
+
+    Sends an explicit User-Agent: some public RPC providers reject urllib's
+    default one with a 403, which would otherwise look like an unreachable node.
+    """
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": "eth_chainId", "params": []}).encode()
+    request = urllib.request.Request(rpc_url, data=payload, headers={
+        "Content-Type": "application/json",
+        "User-Agent": "underscore-migrate/1.0",
+    })
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                return int(json.load(response)["result"], 16)
+        except Exception:
+            if attempt == attempts - 1:
+                return None
+    return None
+
+
+def assert_eth_mainnet_allowed(chain, rpc_url, fork):
+    """Refuse to run a live migration against Ethereum mainnet by accident.
+
+    A Hightop user wallet address is `CREATE(hatchery, nonce)`, and a hatchery
+    address is `CREATE(deployer, nonce)`. When a user sends a deposit to their
+    wallet address on Ethereum mainnet instead of Base, the only way to recover
+    it is to reproduce that exact CREATE chain on mainnet -- which requires the
+    deployer account to still be at the right mainnet nonce. Any real mainnet
+    transaction from a deployer account burns nonces and permanently destroys
+    that recovery path for every affected user.
+
+    Deploying to Ethereum mainnet must therefore be a deliberate, reviewed act.
+    Set `ALLOW_ETH_MAINNET_DEPLOY=1` to override once the nonce impact on
+    outstanding recoveries has been signed off.
+    """
+    if fork or chain == "local" or rpc_url == "boa":
+        return
+
+    if chain == "eth-mainnet":
+        chain_id = ETH_MAINNET_CHAIN_ID
+    else:
+        chain_id = resolve_chain_id(rpc_url)
+        if chain_id is None and os.environ.get(ALLOW_ETH_MAINNET_ENV) != "1":
+            # Fail closed: a blocked deploy costs minutes, but an unnoticed
+            # mainnet deploy permanently destroys user recovery. `--chain` alone
+            # is not trustworthy here, since `--rpc` overrides where we connect.
+            raise click.ClickException(
+                f"Could not verify the chain id of `{rpc_url}`, so this run "
+                "cannot rule out Ethereum mainnet.\n"
+                f"Re-run with {ALLOW_ETH_MAINNET_ENV}=1 once you have confirmed "
+                "the target chain.")
+    if chain_id != ETH_MAINNET_CHAIN_ID:
+        return
+
+    if os.environ.get(ALLOW_ETH_MAINNET_ENV) == "1":
+        log.error(
+            f"{ALLOW_ETH_MAINNET_ENV}=1 -- proceeding on Ethereum mainnet. "
+            "This burns deployer nonces and may permanently destroy "
+            "misdirected-deposit recovery for existing users.")
+        return
+
+    raise click.ClickException(
+        "Refusing to migrate against Ethereum mainnet (chainId 1).\n"
+        "Deployer nonces on mainnet are the only recovery lever for deposits "
+        "misdirected to a user wallet address, and this run would burn them "
+        "irreversibly.\n"
+        f"If this is intended and signed off, re-run with {ALLOW_ETH_MAINNET_ENV}=1.")
 
 
 def param_prompt(ctx, param, value):
@@ -269,6 +346,8 @@ def cli(
 
     final_rpc = rpc if rpc else (
         'boa' if chain == 'local' else f"https://{chain}.g.alchemy.com/v2/{os.environ.get('WEB3_ALCHEMY_API_KEY')}")
+
+    assert_eth_mainnet_allowed(chain, final_rpc, fork)
 
     if safe != "":
         if fork:

--- a/tests/scripts/test_eth_mainnet_guard.py
+++ b/tests/scripts/test_eth_mainnet_guard.py
@@ -1,0 +1,70 @@
+import os
+
+import click
+import pytest
+
+# `scripts.migrate` reads ETHERSCAN_API_KEY at import time.
+os.environ.setdefault("ETHERSCAN_API_KEY", "test")
+
+from scripts.migrate import (  # noqa: E402
+    ALLOW_ETH_MAINNET_ENV,
+    ETH_MAINNET_CHAIN_ID,
+    assert_eth_mainnet_allowed,
+)
+
+BASE_RPC = "https://base-mainnet.example/v2/key"
+ETH_RPC = "https://eth-mainnet.example/v2/key"
+
+
+@pytest.fixture(autouse=True)
+def _no_override(monkeypatch):
+    monkeypatch.delenv(ALLOW_ETH_MAINNET_ENV, raising=False)
+
+
+@pytest.fixture
+def chain_id(monkeypatch):
+    """Stub the chain id probe so tests never touch the network."""
+    def _set(value):
+        monkeypatch.setattr(
+            "scripts.migrate.resolve_chain_id", lambda *_a, **_k: value)
+    return _set
+
+
+def test_blocks_explicit_eth_mainnet_without_probing(chain_id):
+    chain_id(None)  # name alone must be enough
+    with pytest.raises(click.ClickException):
+        assert_eth_mainnet_allowed("eth-mainnet", ETH_RPC, fork=False)
+
+
+def test_blocks_when_rpc_is_mainnet_despite_innocent_chain_name(chain_id):
+    """`--rpc` decides where we connect, so `--chain` alone is not trustworthy."""
+    chain_id(ETH_MAINNET_CHAIN_ID)
+    with pytest.raises(click.ClickException):
+        assert_eth_mainnet_allowed("base-mainnet", ETH_RPC, fork=False)
+
+
+def test_fails_closed_when_chain_id_is_unverifiable(chain_id):
+    chain_id(None)
+    with pytest.raises(click.ClickException):
+        assert_eth_mainnet_allowed("base-mainnet", BASE_RPC, fork=False)
+
+
+def test_allows_base_mainnet(chain_id):
+    chain_id(8453)
+    assert_eth_mainnet_allowed("base-mainnet", BASE_RPC, fork=False)
+
+
+def test_allows_local_and_forks_without_probing(chain_id):
+    chain_id(None)
+    assert_eth_mainnet_allowed("local", "boa", fork=False)
+    assert_eth_mainnet_allowed("eth-mainnet", ETH_RPC, fork=True)
+
+
+@pytest.mark.parametrize("chain,probe", [
+    ("eth-mainnet", ETH_MAINNET_CHAIN_ID),
+    ("base-mainnet", None),
+])
+def test_override_env_permits_the_run(monkeypatch, chain_id, chain, probe):
+    chain_id(probe)
+    monkeypatch.setenv(ALLOW_ETH_MAINNET_ENV, "1")
+    assert_eth_mainnet_allowed(chain, ETH_RPC, fork=False)


### PR DESCRIPTION
A Hightop user wallet address is `CREATE(hatchery, nonce)`, and a hatchery
address is `CREATE(deployer, nonce)`. When a user sends a deposit to their
wallet address on Ethereum mainnet instead of Base, the only way to recover it
is to reproduce that CREATE chain on mainnet — which requires the deployer
account to still be at the right mainnet nonce.

Three deployer keys are currently recovery-critical, and all three still have
their windows open:

| key | mainnet nonce | window | covers |
|---|---|---|---|
| `0x14051A64…FD8e` | 0 | 110 | retired H1 wallets |
| `0x3ED81740…ee15` | 0 | 425 / 560 | H2 + H3 — all current users |
| `0x3fbE7910…9DB7` | 6 | 296 | a wallet holding 4,000 USDC |

Any real mainnet transaction from one of these accounts burns nonces and
destroys the recovery path permanently, for every affected user. Today nothing
prevents it: `--chain eth-mainnet` is a valid choice, and `final_rpc` is
derived from the chain name, so a single flag connects a deployer account
straight to mainnet.

## What this adds

A preflight in `scripts/migrate.py` that resolves the target chain id and
aborts on chainId 1.

- `--chain` alone is not trusted, since `--rpc` overrides where we connect.
- An unverifiable chain id **fails closed**: a blocked deploy costs minutes, an
  unnoticed mainnet deploy is irreversible.
- Forks and `local` are exempt, so simulation is unaffected.
- `ALLOW_ETH_MAINNET_DEPLOY=1` overrides once the nonce impact on outstanding
  recoveries has been signed off.

The chain-id probe sends an explicit `User-Agent` — some public RPC providers
reject urllib's default with a 403, which would otherwise look like an
unreachable node and silently fail open.

## Tests

`tests/scripts/test_eth_mainnet_guard.py` — 7 cases covering the explicit
`eth-mainnet` name, a mainnet RPC behind an innocent chain name, fail-closed on
an unverifiable chain id, normal Base deploys, local/fork exemption, and the
override. The chain-id probe is stubbed, so no network access in tests.